### PR TITLE
This fixes an issue where nodes of the same type could not be selected back to back in the outline tree.

### DIFF
--- a/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVOutlinePage.java
+++ b/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVOutlinePage.java
@@ -147,7 +147,7 @@ public class SVOutlinePage extends ContentOutlinePage
 					if (sel.getFirstElement() instanceof ISVDBItemBase) {
 						ISVDBItemBase it = (ISVDBItemBase)sel.getFirstElement();
 						
-						if (fLastSelection == null || !fLastSelection.equals(it)) {
+						if (fLastSelection == null || !fLastSelection.equals(it, true)) {
 							fEditor.setSelection(it, false);
 							fLastSelection = it;
 						}


### PR DESCRIPTION
SVOutlinePage: fixed selectionChanged() so that is does a full compae of previously selected nodes.
This fixes an issue where nodes of the same type could not be selected back to back.
