### PR TITLE
Fix for (3482259) 	Vectored Delayed Wire type not parsed correctly

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+
+- #(3482259)    Vectored Delayed Wire type not parsed correctly
+
 - #(3476740) 	Module Instance Icon not shown in Outline View
 
 -- 0.7.9 Release --

--- a/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseModuleBodyItems.java
+++ b/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseModuleBodyItems.java
@@ -1447,6 +1447,8 @@ public class TestParseModuleBodyItems extends TestCase {
 			"	wire (strong0, strong1) #myparam [10:0] out3 = '0;\n" +
 			"	wire (supply0, supply1) #(1:2:3)        out4 = 1'b0;\n" +
 			"	wire (weak0, weak1) #(1, 2, 4)          out6 = 1'b0;\n" +
+			"	wire [1:0] #(1, 2, 4)          out7 = '0;\n" +
+			"	//wire [NUM_WIRES:0] #(1, 2, 4)          out8 = '0;\n" +
 			"	reg  in1,in2,in3,in4;\n" +
 			"\n" +
 			"	not U1(out0,in1);\n" +


### PR DESCRIPTION
(3482259)   Vectored Delayed Wire type not parsed correctly

The scalar/vector was parsed after delay instead of before
