### PR TITLE
Cause keyboard-driven selection to treat '_' as part of the word

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,8 @@
+-- 0.8.9 Release --
+
+- #(3526657) - Treat "_" as part of a word, not delimiter
+
+------------------------------------------------------------------------------
 -- 0.8.8 Release --
 
 - #(3526097) - Correct parse error with new <expr>; statement

--- a/etc/sveditor.info
+++ b/etc/sveditor.info
@@ -1,4 +1,4 @@
-version=0.8.8
+version=0.8.9
 update_site_url="$SF_USERNAME,sveditor@web.sourceforge.net:htdocs/update"
 frs_update_site_dir=update_site
 upload_archive=0

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBlockItemDeclParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBlockItemDeclParser.java
@@ -66,7 +66,9 @@ public class SVBlockItemDeclParser extends SVParserBase {
 					type = parsers().dataTypeParser().data_type(0);
 				}
 				
-				debug("type=" + type + " " + fLexer.peek());
+				if (fDebugEn) {
+					debug("type=" + type + " " + fLexer.peek());
+				}
 				
 				// Allow for untyped parameters
 				if (dir != null && fLexer.peekOperator()) {

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/SVUIResources.properties
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/SVUIResources.properties
@@ -69,3 +69,13 @@ PrevWordAction.tooltip=
 PrevWordAction.image=
 PrevWordAction.description=
 
+SelNextWordAction.label=Select Next Word
+SelNextWordAction.tooltip=
+SelNextWordAction.image=
+SelNextWordAction.description=
+
+SelPrevWordAction.label=Select Previous Word
+SelPrevWordAction.tooltip=
+SelPrevWordAction.image=
+SelPrevWordAction.description=
+

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVActionContributor.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVActionContributor.java
@@ -40,6 +40,8 @@ public class SVActionContributor extends TextEditorActionContributor {
 	protected RetargetTextEditorAction fToggleCommentAction;
 	protected RetargetTextEditorAction fNextWordAction;
 	protected RetargetTextEditorAction fPrevWordAction;
+	protected RetargetTextEditorAction fSelNextWordAction;
+	protected RetargetTextEditorAction fSelPrevWordAction;
 	
 	protected MenuManager			   fSourceMenu;
 
@@ -84,6 +86,13 @@ public class SVActionContributor extends TextEditorActionContributor {
 		
 		fPrevWordAction = new RetargetTextEditorAction(bundle, "PrevWordAction.");
 		fPrevWordAction.setActionDefinitionId(ITextEditorActionDefinitionIds.WORD_PREVIOUS);
+		
+		fSelNextWordAction = new RetargetTextEditorAction(bundle, "SelNextWordAction.");
+		fSelNextWordAction.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_NEXT);
+		
+		fSelPrevWordAction = new RetargetTextEditorAction(bundle, "SelPrevWordAction.");
+		fSelPrevWordAction.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_PREVIOUS);
+		
 	}
 
 	public void contributeToMenu(IMenuManager mm) {
@@ -136,6 +145,8 @@ public class SVActionContributor extends TextEditorActionContributor {
 		fToggleCommentAction.setAction(getAction(editor, "ToggleComment"));
 		fNextWordAction.setAction(getAction(editor, "NextWord"));
 		fPrevWordAction.setAction(getAction(editor, "PrevWord"));
+		fSelNextWordAction.setAction(getAction(editor, "SelNextWord"));
+		fSelPrevWordAction.setAction(getAction(editor, "SelPrevWord"));
 	}
 
 	/*

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVEditor.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVEditor.java
@@ -52,6 +52,8 @@ import net.sf.sveditor.ui.editor.actions.OpenTypeHierarchyAction;
 import net.sf.sveditor.ui.editor.actions.OverrideTaskFuncAction;
 import net.sf.sveditor.ui.editor.actions.PrevWordAction;
 import net.sf.sveditor.ui.editor.actions.RemoveBlockCommentAction;
+import net.sf.sveditor.ui.editor.actions.SelNextWordAction;
+import net.sf.sveditor.ui.editor.actions.SelPrevWordAction;
 import net.sf.sveditor.ui.editor.actions.ToggleCommentAction;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -475,6 +477,17 @@ public class SVEditor extends TextEditor
 				bundle, "PrevWordAction.", this);
 		pw_action.setActionDefinitionId(ITextEditorActionDefinitionIds.WORD_PREVIOUS);
 		setAction(ITextEditorActionDefinitionIds.WORD_PREVIOUS, pw_action);
+		
+		SelNextWordAction sel_nw_action = new SelNextWordAction(
+				bundle, "SelNextWordAction.", this);
+		sel_nw_action.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_NEXT);
+		setAction(ITextEditorActionDefinitionIds.SELECT_WORD_NEXT, sel_nw_action);
+		
+		SelPrevWordAction sel_pw_action = new SelPrevWordAction(
+				bundle, "SelPrevWordAction.", this);
+		sel_pw_action.setActionDefinitionId(ITextEditorActionDefinitionIds.SELECT_WORD_PREVIOUS);
+		setAction(ITextEditorActionDefinitionIds.SELECT_WORD_PREVIOUS, sel_pw_action);
+		
 	}
 	
 	/*

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/SelNextWordAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/SelNextWordAction.java
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * Copyright (c) 2008-2011 Matthew Ballance and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Matthew Ballance - initial implementation
+ ****************************************************************************/
+
+
+package net.sf.sveditor.ui.editor.actions;
+
+import java.util.ResourceBundle;
+
+import net.sf.sveditor.core.scanner.SVCharacter;
+import net.sf.sveditor.ui.editor.SVEditor;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.ui.texteditor.TextEditorAction;
+
+public class SelNextWordAction extends TextEditorAction {
+	private SVEditor				fEditor;
+	
+	public SelNextWordAction(
+			ResourceBundle			bundle,
+			String					prefix,
+			SVEditor				editor) {
+		super(bundle, prefix, editor);
+		fEditor = editor;
+	}
+
+	@Override
+	public void run() {
+		StyledText text = fEditor.sourceViewer().getTextWidget();
+		int offset = text.getCaretOffset();
+		int start_offset = offset;
+		
+		String str = text.getText();
+		int len = str.length();
+		
+		int ch = str.charAt(offset);
+		if (SVCharacter.isSVIdentifierPart(ch)) {
+			// scan forward to end or next non-id_part
+			while (offset < len) {
+				ch = str.charAt(offset);
+				if (!SVCharacter.isSVIdentifierPart(ch)) {
+					break;
+				}
+				offset++;
+			}
+		} else {
+			// scan forward to end or next identifier
+			while (offset < len) {
+				ch = str.charAt(offset);
+				if (SVCharacter.isSVIdentifierPart(ch)) {
+					break;
+				}
+				offset++;
+			}
+		}
+		
+		if (offset >= len) {
+			offset = len-1;
+		}
+		
+		text.setSelection(start_offset, offset);
+	}
+}

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/SelPrevWordAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/SelPrevWordAction.java
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright (c) 2008-2011 Matthew Ballance and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Matthew Ballance - initial implementation
+ ****************************************************************************/
+
+
+package net.sf.sveditor.ui.editor.actions;
+
+import java.util.ResourceBundle;
+
+import net.sf.sveditor.core.scanner.SVCharacter;
+import net.sf.sveditor.ui.editor.SVEditor;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.ui.texteditor.TextEditorAction;
+
+public class SelPrevWordAction extends TextEditorAction {
+	private SVEditor				fEditor;
+	
+	public SelPrevWordAction(
+			ResourceBundle			bundle,
+			String					prefix,
+			SVEditor				editor) {
+		super(bundle, prefix, editor);
+		fEditor = editor;
+	}
+
+	@Override
+	public void run() {
+		StyledText text = fEditor.sourceViewer().getTextWidget();
+		int offset = text.getCaretOffset();
+		int start_offset = offset;
+		
+		String str = text.getText();
+		
+		offset--;
+		if (offset < 0) {
+			return;
+		}
+		
+		
+		int ch = str.charAt(offset);
+		if (SVCharacter.isSVIdentifierPart(ch)) {
+			// scan back to end or next non-id_part
+			while (offset >= 0) {
+				ch = str.charAt(offset);
+				if (!SVCharacter.isSVIdentifierPart(ch)) {
+					break;
+				}
+				offset--;
+			}
+		} else {
+			// scan back to end or next identifier
+			while (offset >= 0) {
+				ch = str.charAt(offset);
+				if (SVCharacter.isSVIdentifierPart(ch)) {
+					break;
+				}
+				offset--;
+			}
+		}
+		
+		if (offset < 0) {
+			offset = 0;
+		}
+		text.setSelection((offset+1), start_offset);
+	}
+}


### PR DESCRIPTION
CTRL+SHIFT+-> and CTRL+SHIFT+<- selection correctly consider '_' to be
part of a word.
