### PR TITLE
ignore c and cpp files in arg files

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/svf_scanner/SVFScanner.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/svf_scanner/SVFScanner.java
@@ -399,7 +399,9 @@ public class SVFScanner {
 					tmp.append((char)ch);
 				}
 				
-				fFilePaths.add(tmp.toString());
+				if(!tmp.toString().matches(".*\\.(c|h|cpp|hpp)$")){
+					fFilePaths.add(tmp.toString());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a patch for artifact 3530270.  It explicitly skips parsing of c and cpp files.  It might be cleaner to explicitly state what TO parse instead. I imagine there's already a set of system verilog extensions maintained somewhere in the code base.

https://sourceforge.net/tracker/?func=detail&aid=3530270&group_id=230781&atid=1081015
