### PR TITLE
avoid npe on wizard generated file rename

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/AbstractSVDBIndex.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/AbstractSVDBIndex.java
@@ -874,12 +874,12 @@ public abstract class AbstractSVDBIndex implements ISVDBIndex,
 				
 			if (pp_file == null) {
 				fLog.error("Failed to get pp_file \"" + path + "\" from cache");
-			}
-				
+			} else {
 			SVDBFileTree ft_root = new SVDBFileTree( (SVDBFile) pp_file.duplicate());
 				Set<String> included_files = new HashSet<String>();
 				Map<String, SVDBFileTree> working_set = new HashMap<String, SVDBFileTree>();
 				buildPreProcFileMap(null, ft_root, missing_includes, included_files, working_set);
+			}
 		}
 	}
 


### PR DESCRIPTION
Patch to avoid NPE as per bug 3530974.  Still needs shadow expert to resolve reported errors.  Not familiar enough with index myself.

https://sourceforge.net/tracker/?func=detail&aid=3530974&group_id=230781&atid=1081015
