### PR TITLE
Fix quick view not being receiving keyboard focus on windows OS.

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickHierarchyAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickHierarchyAction.java
@@ -13,20 +13,14 @@
 
 package net.sf.sveditor.ui.editor.actions;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ResourceBundle;
 
 import net.sf.sveditor.ui.editor.SVEditor;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.TextEditorAction;
 
 public class OpenQuickHierarchyAction extends TextEditorAction {
 	
-	private IWorkbench				fWorkbench;
 	private SVEditor fEditor;
 	
 	public OpenQuickHierarchyAction(
@@ -36,32 +30,13 @@ public class OpenQuickHierarchyAction extends TextEditorAction {
 		super(bundle, "OpenQuickHierarchy.", editor) ;
 		
 		fEditor = editor ;
-		
-		fWorkbench = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getWorkbench() ;
 	}
 
 	@Override
 	public void run() {
-		try {
-			fWorkbench.getProgressService().run(false, false, fOpenQuickHierarchy);
-		} catch (InvocationTargetException e) {
-		} catch (InterruptedException e) {
-		}
-	}
-	
-	private IRunnableWithProgress fOpenQuickHierarchy = new IRunnableWithProgress() {
-		
-		public void run(IProgressMonitor monitor) throws InvocationTargetException,
-				InterruptedException {
 			
-			monitor.beginTask("Open quick outline", 2);
+		fEditor.getQuickHierarchyPresenter().showInformation() ;
 			
-			monitor.worked(1);
-			
-			fEditor.getQuickHierarchyPresenter().showInformation() ;
-			
-			monitor.done();
-		}
 	};
 	
 }

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickObjectsViewAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickObjectsViewAction.java
@@ -13,19 +13,14 @@
 
 package net.sf.sveditor.ui.editor.actions;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ResourceBundle;
 
 import net.sf.sveditor.ui.editor.SVEditor;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.PlatformUI;
+
 import org.eclipse.ui.texteditor.TextEditorAction;
 
 public class OpenQuickObjectsViewAction extends TextEditorAction {
 	
-	private IWorkbench				fWorkbench;
 	private SVEditor fEditor;
 	
 	public OpenQuickObjectsViewAction(
@@ -35,33 +30,12 @@ public class OpenQuickObjectsViewAction extends TextEditorAction {
 		super(bundle, "OpenQuickObjects.", editor) ;
 		
 		fEditor = editor ;
-		
-		fWorkbench = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getWorkbench() ;
 	}
 
 	@Override
 	public void run() {
-		try {
-			fWorkbench.getProgressService().run(false, false, fOpenQuickObjects);
-		} catch (InvocationTargetException e) {
-		} catch (InterruptedException e) {
-		}
-	}
-	
-	private IRunnableWithProgress fOpenQuickObjects = new IRunnableWithProgress() {
-		
-		public void run(IProgressMonitor monitor) throws InvocationTargetException,
-				InterruptedException {
 			
-			monitor.beginTask("Open Objects View", 2);
-			
-			monitor.worked(1);
-			
-			fEditor.getQuickObjectsPresenter().showInformation() ;
-			
-			monitor.done();
-		}
+		fEditor.getQuickObjectsPresenter().showInformation() ;
 	};
-	
 
 }

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickOutlineAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenQuickOutlineAction.java
@@ -13,19 +13,14 @@
 
 package net.sf.sveditor.ui.editor.actions;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ResourceBundle;
 
 import net.sf.sveditor.ui.editor.SVEditor;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.PlatformUI;
+
 import org.eclipse.ui.texteditor.TextEditorAction;
 
 public class OpenQuickOutlineAction extends TextEditorAction {
 	
-	private IWorkbench				fWorkbench;
 	private SVEditor fEditor;
 	
 	public OpenQuickOutlineAction(
@@ -35,33 +30,11 @@ public class OpenQuickOutlineAction extends TextEditorAction {
 		super(bundle, "OpenQuickOutline.", editor) ;
 		
 		fEditor = editor ;
-		
-		fWorkbench = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getWorkbench() ;
 	}
 
-	@Override
 	public void run() {
-		try {
-			fWorkbench.getProgressService().run(false, false, fOpenQuickOutline);
-		} catch (InvocationTargetException e) {
-		} catch (InterruptedException e) {
-		}
-	}
-	
-	private IRunnableWithProgress fOpenQuickOutline = new IRunnableWithProgress() {
 		
-		public void run(IProgressMonitor monitor) throws InvocationTargetException,
-				InterruptedException {
-			
-			monitor.beginTask("Open quick outline", 2);
-			
-			monitor.worked(1);
-			
-			fEditor.getQuickOutlinePresenter().showInformation() ;
-			
-			monitor.done();
-		}
-	};
-	
-
+		fEditor.getQuickOutlinePresenter().showInformation() ;
+		
+	}
 }


### PR DESCRIPTION
Removed progross display as quick view comes up "quickly" and because it was taking the focus away on windows OS
