### PR TITLE
diag model separated from ui. fix for diag for class ctxt

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/AbstractDiagModelFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/AbstractDiagModelFactory.java
@@ -9,7 +9,7 @@
  *     Armond Paiva - initial contributor 
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.core.diagrams;
 
 import java.util.HashMap;
 import java.util.List;
@@ -24,9 +24,6 @@ import net.sf.sveditor.core.db.search.SVDBFindClassDefaultNameMatcher;
 import net.sf.sveditor.core.db.search.SVDBFindNamedClass;
 import net.sf.sveditor.core.db.stmt.SVDBVarDeclItem;
 import net.sf.sveditor.core.db.stmt.SVDBVarDeclStmt;
-import net.sf.sveditor.core.diagrams.DiagConnection;
-import net.sf.sveditor.core.diagrams.DiagConnectionType;
-import net.sf.sveditor.core.diagrams.DiagNode;
 
 public abstract class AbstractDiagModelFactory implements IDiagModelFactory {
 	

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/ClassDiagModelFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/ClassDiagModelFactory.java
@@ -10,16 +10,13 @@
  *     Armond Paiva - initial contributor 
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.core.diagrams;
 
 import net.sf.sveditor.core.db.ISVDBChildParent;
 import net.sf.sveditor.core.db.SVDBClassDecl;
 import net.sf.sveditor.core.db.SVDBItemType;
 import net.sf.sveditor.core.db.index.ISVDBIndex;
 import net.sf.sveditor.core.db.search.SVDBFindSuperClass;
-import net.sf.sveditor.core.diagrams.DiagConnection;
-import net.sf.sveditor.core.diagrams.DiagConnectionType;
-import net.sf.sveditor.core.diagrams.DiagNode;
 
 public class ClassDiagModelFactory extends AbstractDiagModelFactory {
 	

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/DiagModel.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/DiagModel.java
@@ -9,14 +9,12 @@
  *     Armond Paiva - initial contributor 
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.core.diagrams;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import net.sf.sveditor.core.diagrams.DiagConnection;
-import net.sf.sveditor.core.diagrams.DiagNode;
 
 public class DiagModel {
 	

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/IDiagModelFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/IDiagModelFactory.java
@@ -9,7 +9,8 @@
  *     Armond Paiva - initial contributor 
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.core.diagrams;
+
 
 public interface IDiagModelFactory {
 	

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/PackageClassDiagModelFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/diagrams/PackageClassDiagModelFactory.java
@@ -10,7 +10,7 @@
  *     Armond Paiva - initial contributor 
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.core.diagrams;
 
 import java.util.List;
 

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenDiagForSelectionAction.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/actions/OpenDiagForSelectionAction.java
@@ -20,12 +20,12 @@ import net.sf.sveditor.core.db.ISVDBItemBase;
 import net.sf.sveditor.core.db.SVDBClassDecl;
 import net.sf.sveditor.core.db.SVDBItemType;
 import net.sf.sveditor.core.db.SVDBPackageDecl;
+import net.sf.sveditor.core.diagrams.ClassDiagModelFactory;
+import net.sf.sveditor.core.diagrams.DiagModel;
+import net.sf.sveditor.core.diagrams.IDiagModelFactory;
+import net.sf.sveditor.core.diagrams.PackageClassDiagModelFactory;
 import net.sf.sveditor.ui.SVUiPlugin;
 import net.sf.sveditor.ui.editor.SVEditor;
-import net.sf.sveditor.ui.views.diagram.ClassDiagModelFactory;
-import net.sf.sveditor.ui.views.diagram.DiagModel;
-import net.sf.sveditor.ui.views.diagram.IDiagModelFactory;
-import net.sf.sveditor.ui.views.diagram.PackageClassDiagModelFactory;
 import net.sf.sveditor.ui.views.diagram.SVDiagramView;
 
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/DiagContentProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/DiagContentProvider.java
@@ -16,7 +16,7 @@ import net.sf.sveditor.core.diagrams.DiagNode;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.zest.core.viewers.IGraphEntityContentProvider;
 
-public class NodeContentProvider extends ArrayContentProvider implements IGraphEntityContentProvider {
+public class DiagContentProvider extends ArrayContentProvider implements IGraphEntityContentProvider {
 	
 	public Object[] getConnectedTo(Object entity) {
 		if (entity instanceof DiagNode) {

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/DiagLabelProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/DiagLabelProvider.java
@@ -21,6 +21,7 @@ import net.sf.sveditor.core.db.stmt.SVDBVarDeclItem;
 import net.sf.sveditor.core.diagrams.DiagConnection;
 import net.sf.sveditor.core.diagrams.DiagNode;
 import net.sf.sveditor.ui.SVDBIconUtils;
+import net.sf.sveditor.ui.views.diagram.figures.UMLClassFigure;
 
 import org.eclipse.draw2d.ConnectionRouter;
 import org.eclipse.draw2d.IFigure;

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/SVDiagramView.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/SVDiagramView.java
@@ -15,10 +15,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 import net.sf.sveditor.core.db.index.ISVDBIndex;
+import net.sf.sveditor.core.diagrams.DiagModel;
 import net.sf.sveditor.core.diagrams.DiagNode;
+import net.sf.sveditor.core.diagrams.IDiagModelFactory;
 import net.sf.sveditor.ui.SVDBIconUtils;
 import net.sf.sveditor.ui.SVEditorUtil;
-import net.sf.sveditor.ui.views.diagram.context_menu.NewDiagramForClassContributionItem;
+import net.sf.sveditor.ui.views.diagram.contributions.NewDiagramForClassContributionItem;
+import net.sf.sveditor.ui.views.diagram.contributions.NewDiagramForClassHandler;
 
 import org.eclipse.draw2d.FanRouter;
 import org.eclipse.draw2d.Graphics;
@@ -32,6 +35,7 @@ import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.IDoubleClickListener;
@@ -61,6 +65,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.IViewSite;
+import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -143,6 +148,7 @@ public class SVDiagramView extends ViewPart implements SelectionListener, IZooma
 
 	protected void fillContextMenu(IMenuManager mgr) {
 		mgr.add(fNewDiagramForClassContributionItem) ;
+		mgr.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS)) ;
 	}
 	private void createContributions() {
 		fNewDiagramForClassHandler = new NewDiagramForClassHandler() ;
@@ -153,7 +159,7 @@ public class SVDiagramView extends ViewPart implements SelectionListener, IZooma
 		GridData gd;
 		fGraphViewer = new GraphViewer(parent, SWT.BORDER) ;
 		fDiagLabelProvider = new DiagLabelProvider() ;
-		fGraphViewer.setContentProvider(new NodeContentProvider()) ;
+		fGraphViewer.setContentProvider(new DiagContentProvider()) ;
 		fGraphViewer.setLabelProvider((IBaseLabelProvider)fDiagLabelProvider) ;
 		fGraphViewer.setInput(fModel == null ? null : fModel.getNodes()) ;
 		

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/contributions/NewDiagramForClassContributionItem.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/contributions/NewDiagramForClassContributionItem.java
@@ -9,7 +9,7 @@
  *     Armond Paiva - initial contributor
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram.context_menu;
+package net.sf.sveditor.ui.views.diagram.contributions;
 
 import java.util.Collections;
 
@@ -49,7 +49,7 @@ public class NewDiagramForClassContributionItem extends ContributionItem {
 				new ISelectionChangedListener() {
 					public void selectionChanged(SelectionChangedEvent event) {
 						ISelection selection = event.getSelection() ;
-						fEnabled = false ;
+						fEnabled = false ; fClassDecl = null ;
 						if(!selection.isEmpty() && selection instanceof IStructuredSelection) {
 							IStructuredSelection structuredSel = (IStructuredSelection)selection ;
 							if(structuredSel.size() == 1) {  
@@ -65,6 +65,11 @@ public class NewDiagramForClassContributionItem extends ContributionItem {
 						updateEnablement() ;
 					}
 				} ) ;
+	}
+	
+	@Override
+	public boolean isDynamic() {
+		return true ;
 	}
 
 	protected void updateEnablement() {

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/contributions/NewDiagramForClassHandler.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/contributions/NewDiagramForClassHandler.java
@@ -9,11 +9,15 @@
  *     Armond Paiva - initial contributor
  ****************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.ui.views.diagram.contributions;
 
 import net.sf.sveditor.core.db.SVDBClassDecl;
 import net.sf.sveditor.core.db.index.ISVDBIndex;
+import net.sf.sveditor.core.diagrams.ClassDiagModelFactory;
+import net.sf.sveditor.core.diagrams.DiagModel;
+import net.sf.sveditor.core.diagrams.IDiagModelFactory;
 import net.sf.sveditor.ui.SVUiPlugin;
+import net.sf.sveditor.ui.views.diagram.SVDiagramView;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/figures/CompartmentFigure.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/figures/CompartmentFigure.java
@@ -10,7 +10,7 @@
  * 		Armond Paiva - Repurposed for use in SVEditor 
  ******************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.ui.views.diagram.figures;
 
 import org.eclipse.draw2d.AbstractBorder;
 import org.eclipse.draw2d.Figure;

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/figures/UMLClassFigure.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/views/diagram/figures/UMLClassFigure.java
@@ -11,7 +11,8 @@
  * 
  ******************************************************************************/
 
-package net.sf.sveditor.ui.views.diagram;
+package net.sf.sveditor.ui.views.diagram.figures;
+
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Figure;


### PR DESCRIPTION
Mostly cleanup of the various diagram related class files.  

Fixes a bug where the diagram context menu item for opening a new diagram for the selected class wasn't updating the class name when selecting a new class.
