### PR TITLE
Added integral and const tests

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestTypeDeclarations.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestTypeDeclarations.java
@@ -62,51 +62,24 @@ public class TestTypeDeclarations extends TestCase {
 	}
 
 	public void testTypeParameterizedClass() {
-		String content = 
-			"class t;\n" +
-			"	function f();\n" +
-			"		item_t #(int unsigned)::set(5);\n" +
-			"	endfunction\n" +
-			"endclass\n"
-			;
-		SVCorePlugin.getDefault().enableDebug(false);
-		SVDBFile file = SVDBTestUtils.parse(content, "testParameterizedFieldTypeInit");
-
-		SVDBTestUtils.assertNoErrWarn(file);
-
-		SVDBTestUtils.assertFileHasElements(file, "t", "f");
+		testTypeCastInFunction("		item_t #(int unsigned)::set(5);\n");
 	}
 
 	public void testBuiltinTypeCast() {
-		String content = 
-			"class t;\n" +
-			"	function f();\n" +
-			"		int i = int'(test_func());\n" +
-			"	endfunction\n" +
-			"endclass\n"
-			;
-		SVCorePlugin.getDefault().enableDebug(false);
-		SVDBFile file = SVDBTestUtils.parse(content, "testParameterizedFieldTypeInit");
-
-		SVDBTestUtils.assertNoErrWarn(file);
-
-		SVDBTestUtils.assertFileHasElements(file, "t", "f");
+		testTypeCastInFunction("		int i = int'(test_func());\n");
 	}
-
+	
+	public void testIntegralTypeCast() {
+		testTypeCastInFunction("		bit[5:0] i = 6'(test_func());\n");
+	}
+	
 	public void testVoidCast() {
-		String content = 
-			"class t;\n" +
-			"	function f();\n" +
-			"		void'(test_func());\n" +
-			"	endfunction\n" +
-			"endclass\n"
-			;
-		SVCorePlugin.getDefault().enableDebug(false);
-		SVDBFile file = SVDBTestUtils.parse(content, "testParameterizedFieldTypeInit");
-
-		SVDBTestUtils.assertNoErrWarn(file);
-
-		SVDBTestUtils.assertFileHasElements(file, "t", "f");
+		testTypeCastInFunction("		void'(test_func());\n");
+	}
+	
+	public void testConstTypeCast() {
+		//const cast not supported by Questa at the moment it seems.
+		testTypeCastInFunction("		int i = const'(test_func());\n");
 	}
 
 	public void testParameterizedFieldInit() {
@@ -138,6 +111,22 @@ public class TestTypeDeclarations extends TestCase {
 		SVDBTestUtils.assertNoErrWarn(file);
 
 		SVDBTestUtils.assertFileHasElements(file, "t", "str_int_map1", "str_int_map2");
+	}
+	
+	protected void testTypeCastInFunction(String castExpresson) {
+		String content = 
+			"class t;\n" +
+			"	function f();\n" +
+			castExpresson +
+			"	endfunction\n" +
+			"endclass\n"
+			;
+		SVCorePlugin.getDefault().enableDebug(false);
+		SVDBFile file = SVDBTestUtils.parse(content, "testParameterizedFieldTypeInit");
+
+		SVDBTestUtils.assertNoErrWarn(file);
+
+		SVDBTestUtils.assertFileHasElements(file, "t", "f");
 	}
 
 }


### PR DESCRIPTION
As per https://sourceforge.net/tracker/?func=detail&aid=3558622&group_id=230781&atid=1081015

In reality, const cast not supported by Questa at present, it seems -- at least I couldn't create a sensible example that compiles, but it is in the spec. The integral cast is the more interesting one. Haven't had a chance to look at the actual code, but at least here is a test case.
