### PR TITLE
Bug 3566417 fixed (macro parameter processing)

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/scanner/SVPreProcDefineProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/scanner/SVPreProcDefineProvider.java
@@ -501,6 +501,11 @@ public class SVPreProcDefineProvider implements IDefineProvider {
 			// Skip over the parameter-separator or the closing paren
 			debug("    Try Skip: next ch=" + (char)ch);
 			if (ch == ',' || ch == ')') {
+				if(ch == ')') {
+					//Last parameter parsed
+					ch = scanner.get_ch();
+					break;
+				}
 				ch = scanner.get_ch();
 			}
 		}


### PR DESCRIPTION
Macro parameter parsing was continuing past the end of a macro if the macro had default arguments and they weren't being supplied.
