### PR TITLE
Deprecate Source Collection and Library Path

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -48,7 +48,12 @@
 
 - #(3571086) - Limit maximum errors per file. Currently, error limit is 
   hard-coded to 100
-
+  
+- Update SVEditor Project Properties to place Library Path and Source Collection
+  methods of specifying index paths on a new Deprecated tab. These methods of
+  specifying index paths will gradually be removed. New development will focus
+  on the Argument File method of index specification.
+  
 ------------------------------------------------------------------------------
 -- 0.9.9 Release --
 

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/prop_pages/DeprecatedPropertiesPage.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/prop_pages/DeprecatedPropertiesPage.java
@@ -1,0 +1,70 @@
+package net.sf.sveditor.ui.prop_pages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.sveditor.core.db.project.SVProjectFileWrapper;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.TabItem;
+
+public class DeprecatedPropertiesPage implements ISVProjectPropsPage {
+	private List<ISVProjectPropsPage>			fSubPages;
+	private IProject							fProject;
+	private SVProjectFileWrapper				fProjectWrapper;
+	
+	public DeprecatedPropertiesPage(IProject p) {
+		fSubPages = new ArrayList<ISVProjectPropsPage>();
+		fProject = p;
+	}
+
+	public String getName() {
+		return "Deprecated";
+	}
+
+	public Image getIcon() {
+		return null;
+	}
+
+	public void init(SVProjectFileWrapper project_wrapper) {
+		fProjectWrapper = project_wrapper;
+	}
+
+	public Control createContents(Composite parent) {
+		fSubPages.add(new GlobalDefinesPage(fProject));
+		fSubPages.add(new SourceCollectionsPage(fProject));
+		fSubPages.add(new LibraryPathsPage(fProject));
+		
+		TabFolder folder = new TabFolder(parent, SWT.NONE);
+		TabItem item;
+		
+		for (ISVProjectPropsPage p : fSubPages) {
+			p.init(fProjectWrapper);
+			
+			item = new TabItem(folder, SWT.NONE);
+			item.setText(p.getName());
+			
+			if (p.getIcon() != null) {
+				item.setImage(p.getIcon());
+			}
+			
+			item.setControl(p.createContents(folder));
+		}
+		
+		Dialog.applyDialogFont(folder);
+
+		return folder;
+	}
+
+	public void perfomOk() {
+		for (ISVProjectPropsPage p : fSubPages) {
+			p.perfomOk();
+		}
+	}
+}


### PR DESCRIPTION
Update SVEditor Project Properties to place Library Path and Source Collection
  methods of specifying index paths on a new Deprecated tab. These methods of
  specifying index paths will gradually be removed. New development will focus
  on the Argument File method of index specification.
