### PR TITLE
fix parsing of union declarations in tasks

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseFunction.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseFunction.java
@@ -119,7 +119,23 @@ public class TestParseFunction extends TestCase {
 		parse_tf(content, testname);
 	}
 
-
+	public void testTaskWithUnion() throws SVParseException {
+		String testname = "testTaskWithUnion";
+		SVCorePlugin.getDefault().enableDebug(false);
+		String content =
+			" task test_with_union;\n" +
+			"   union packed {\n" +
+			"       logic [31:0] vector;\n" +
+			"       struct packed {\n" +
+			"          logic[31:16] top;\n" +
+			"          logic[15:0] bottom;\n" +
+			"       } fields;\n" +
+			"   } union_xyz;\n" +
+			" endtask;\n"
+		    ;
+		parse_tf(content, testname);
+		
+	}
 
 	// Tests that local variables are correctly recognized and that 
 	// cast expressions are skipped appropriately

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBehavioralBlockParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBehavioralBlockParser.java
@@ -105,13 +105,13 @@ public class SVBehavioralBlockParser extends SVParserBase {
 
 		// Try for a declaration here
 		if (fLexer.peekKeyword(decl_keywords) || fLexer.peekKeyword(SVKeywords.fBuiltinDeclTypes) ||
-				fLexer.isIdentifier() || fLexer.peekKeyword("typedef","struct","enum","virtual")) {
+				fLexer.isIdentifier() || fLexer.peekKeyword("typedef","struct","union","enum","virtual")) {
 //			boolean builtin_type = fLexer.peekKeyword(SVKeywords.fBuiltinDeclTypes);
 
 			if (fDebugEn) {debug(" -- possible variable declaration " + fLexer.peek());}
 
 			if (fLexer.peekKeyword(decl_keywords) || fLexer.peekKeyword(SVKeywords.fBuiltinDeclTypes) ||
-					fLexer.peekKeyword("typedef","struct","enum","virtual")) {
+					fLexer.peekKeyword("typedef","struct","union", "enum","virtual")) {
 				// Definitely a declaration
 				if (fDebugEn) {debug(" -- variable declaration 1 " + fLexer.peek());}
 				if (!decl_allowed) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBlockItemDeclParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVBlockItemDeclParser.java
@@ -59,7 +59,7 @@ public class SVBlockItemDeclParser extends SVParserBase {
 			// String id = fLexer.eatToken();
 			if (((fLexer.peekKeyword(SVKeywords.fBuiltinTypes)) && !fLexer.peekKeyword("void")) ||
 					!SVKeywords.isSVKeyword(fLexer.peek()) || 
-					fLexer.peekKeyword("struct","enum","virtual")) {
+					fLexer.peekKeyword("struct","union","enum","virtual")) {
 				String name = null;
 				// Data declaration or statement
 				if (type == null) {


### PR DESCRIPTION
There was a slight oversight in the parser where it wasn't checking for unions.  I added a fix and a test case.
