### PR TITLE
Add selective enablement for non-LRM-compliant code

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -21,9 +21,13 @@
 
 - #(nobug) Covergroup <name> with function sample was creating errors, and cratering the file in progress.  Modification
            done to run to end of line, and treat as a normal, simple covergroup.
+           
 - #(165)   Outline view does not jump when selecting primitives
+
 - #(170)   Outline view does not jump when selecting properties 
-    
+
+- #(247) - Support this case (if (a inside b)) as a non-LRM-compliant case. Added an extensible
+  preference scheme to allow the user to selectively enable non-LRM cases.
 
 ------------------------------------------------------------------------------
 -- 1.1.8 Release --

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/lexer/TestClassItems.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/lexer/TestClassItems.java
@@ -19,6 +19,7 @@ import net.sf.sveditor.core.log.LogHandle;
 import net.sf.sveditor.core.parser.ISVParser;
 import net.sf.sveditor.core.parser.SVLexer;
 import net.sf.sveditor.core.parser.SVParseException;
+import net.sf.sveditor.core.parser.SVParserConfig;
 import net.sf.sveditor.core.parser.SVParsers;
 import net.sf.sveditor.core.scanutils.StringTextScanner;
 
@@ -72,6 +73,11 @@ public class TestClassItems extends TestCase {
 			public void error(String msg) {}
 			
 			public void debug(String msg, Exception e) {}
+
+			public SVParserConfig getConfig() {
+				return null;
+			}
+			
 		};
 		lexer.init(parser, new StringTextScanner(content));
 		

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseFunction.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseFunction.java
@@ -28,13 +28,23 @@ import net.sf.sveditor.core.db.stmt.SVDBVarDeclItem;
 import net.sf.sveditor.core.db.stmt.SVDBVarDeclStmt;
 import net.sf.sveditor.core.parser.ParserSVDBFileFactory;
 import net.sf.sveditor.core.parser.SVParseException;
+import net.sf.sveditor.core.parser.SVParserConfig;
 
 public class TestParseFunction extends TestCase {
 	
+
 	private SVDBTask parse_tf(String content, String name) throws SVParseException {
+		return parse_tf(null, content, name);
+	}
+	
+	private SVDBTask parse_tf(SVParserConfig config, String content, String name) throws SVParseException {
 		SVDBScopeItem scope = new SVDBScopeItem();
 		ParserSVDBFileFactory parser = new ParserSVDBFileFactory(null);
 		parser.init(new StringInputStream(content), name);
+		
+		if (config != null) {
+			parser.setConfig(config);
+		}
 		
 		parser.parsers().taskFuncParser().parse(scope, null, 0);
 
@@ -260,10 +270,13 @@ public class TestParseFunction extends TestCase {
 			"end\n" +
 			"endtask\n"				
 			;
+		SVParserConfig config = new SVParserConfig();
+		
+		config.setAllowInsideQWithoutBraces(true);
 		
 		SVCorePlugin.getDefault().enableDebug(false);
 		
-		parse_tf(content, "testIfInside");
+		parse_tf(config, content, "testIfInside");
 	}
 
 	public void testAutomaticFunction() throws SVParseException {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/SVCorePlugin.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/SVCorePlugin.java
@@ -49,6 +49,7 @@ import net.sf.sveditor.core.log.ILogLevel;
 import net.sf.sveditor.core.log.ILogListener;
 import net.sf.sveditor.core.log.LogFactory;
 import net.sf.sveditor.core.parser.ParserSVDBFileFactory;
+import net.sf.sveditor.core.parser.SVParserConfig;
 import net.sf.sveditor.core.scanner.IDefineProvider;
 import net.sf.sveditor.core.templates.TemplateRegistry;
 
@@ -96,11 +97,13 @@ public class SVCorePlugin extends Plugin
 	private TemplateRegistry				fTemplateRgy;
 	private static boolean				fEnableAsyncCacheClear;
 	private static boolean				fTestMode = false;
+	private SVParserConfig				fParserConfig;
 	
 	/**
 	 * The constructor
 	 */
 	public SVCorePlugin() {
+		fParserConfig = new SVParserConfig();
 	}
 
 	/*
@@ -143,6 +146,10 @@ public class SVCorePlugin extends Plugin
 		return fTestMode;
 	}
 	
+	public SVParserConfig getParserConfig() {
+		return fParserConfig;
+	}
+	
 	public boolean getEnableAsyncCacheClear() {
 		return fEnableAsyncCacheClear;
 	}
@@ -172,7 +179,10 @@ public class SVCorePlugin extends Plugin
 	}
 	
 	public static ISVDBFileFactory createFileFactory(IDefineProvider dp) {
-		return new ParserSVDBFileFactory(dp);
+		ParserSVDBFileFactory f = new ParserSVDBFileFactory(dp);
+		f.setConfig(getDefault().getParserConfig());
+		
+		return f;
 	}
 	
 	public ISVIndenter createIndenter() {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/AbstractSVDBIndex.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/AbstractSVDBIndex.java
@@ -64,6 +64,7 @@ import net.sf.sveditor.core.log.ILogLevel;
 import net.sf.sveditor.core.log.ILogLevelListener;
 import net.sf.sveditor.core.log.LogFactory;
 import net.sf.sveditor.core.log.LogHandle;
+import net.sf.sveditor.core.parser.ParserSVDBFileFactory;
 import net.sf.sveditor.core.preproc.SVPreProcDirectiveScanner;
 import net.sf.sveditor.core.preproc.SVPreProcessor;
 import net.sf.sveditor.core.scanner.FileContextSearchMacroProvider;
@@ -1707,7 +1708,7 @@ public abstract class AbstractSVDBIndex implements
 		}
 		SVPreProcDefineProvider dp = new SVPreProcDefineProvider(null);
 		ISVDBFileFactory factory = SVCorePlugin.createFileFactory(dp);
-
+		
 		path = SVFileUtils.normalize(path);
 
 		SVDBFileTree file_tree = findFileTree(path, false);

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/SVDBArgFileIndexFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/SVDBArgFileIndexFactory.java
@@ -18,7 +18,7 @@ public class SVDBArgFileIndexFactory implements ISVDBIndexFactory {
 	
 	public static final String	TYPE = "net.sf.sveditor.argFileIndex";
 	
-	public static boolean		fUseArgFile2Index = false;
+	public static boolean		fUseArgFile2Index = true;
 
 	public ISVDBIndex createSVDBIndex(
 			String 					projectName, 

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprUtilsParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprUtilsParser.java
@@ -18,6 +18,7 @@ import net.sf.sveditor.core.log.LogHandle;
 import net.sf.sveditor.core.parser.ISVParser;
 import net.sf.sveditor.core.parser.SVLexer;
 import net.sf.sveditor.core.parser.SVParseException;
+import net.sf.sveditor.core.parser.SVParserConfig;
 import net.sf.sveditor.core.parser.SVParsers;
 import net.sf.sveditor.core.scanutils.StringTextScanner;
 
@@ -83,6 +84,10 @@ public class SVExprUtilsParser implements ISVParser {
 
 	public SVParsers parsers() {
 		return fParsers;
+	}
+	
+	public SVParserConfig getConfig() {
+		return null;
 	}
 
 	public void debug(String msg, Exception e) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ISVParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ISVParser.java
@@ -38,4 +38,6 @@ public interface ISVParser {
 	
 	ILogHandle getLogHandle();
 	
+	SVParserConfig getConfig();
+	
 }

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ParserSVDBFileFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ParserSVDBFileFactory.java
@@ -82,6 +82,7 @@ public class ParserSVDBFileFactory implements ISVScanner,
 	private List<SVDBMarker>			fMarkers;
 	private boolean						fDisableErrors;
 	private ISVPreProcFileMapper		fFileMapper;
+	private SVParserConfig				fConfig;
 	
 	public ParserSVDBFileFactory() {
 		this(null);
@@ -99,6 +100,16 @@ public class ParserSVDBFileFactory implements ISVScanner,
 
 		fParseErrorCount = 0;
 		fParseErrorMax = 100;
+		
+		fConfig = new SVParserConfig();
+	}
+	
+	public void setConfig(SVParserConfig config) {
+		fConfig = config;
+	}
+	
+	public SVParserConfig getConfig() {
+		return fConfig;
 	}
 
 	public void setDefineProvider(IDefineProvider p) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
@@ -660,8 +660,13 @@ public class SVExprParser extends SVParserBase {
 		} else if (fLexer.peekKeyword("inside")) {
 			fLexer.eatToken();
 			SVDBInsideExpr inside = new SVDBInsideExpr(a);
-			
-			open_range_list(inside.getValueRangeList());
+
+			if (fLexer.peekId() &&
+					getConfig().allowInsideQWithoutBraces()) {
+				inside.getValueRangeList().add(idExpr());
+			} else {
+				open_range_list(inside.getValueRangeList());
+			}
 			
 			a = inside;
 			

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParserBase.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParserBase.java
@@ -88,6 +88,10 @@ public class SVParserBase implements ISVParser, ILogLevelListener {
 	public void debug(String msg, Exception e) {
 		fParser.debug(msg, e);
 	}
+	
+	public SVParserConfig getConfig() {
+		return fParser.getConfig();
+	}
 
 	protected void setStartLocation(SVDBItem item) {
 		item.setLocation(getLocation());

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParserConfig.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParserConfig.java
@@ -1,0 +1,70 @@
+package net.sf.sveditor.core.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class SVParserConfig {
+	
+	public static final String 		ALLOW_INSIDE_Q_WITHOUT_BRACES = "ALLOW_INSIDE_Q_WITHOUT_BRACES";
+	
+	private static final Map<String, String>		fDescMap;
+	private static final Map<String, String>		fShortDescMap;
+	
+	static {
+		fDescMap = new HashMap<String, String>();
+		fShortDescMap = new HashMap<String, String>();
+		
+		fDescMap.put(ALLOW_INSIDE_Q_WITHOUT_BRACES,
+				"Allow behavioral <field> inside <queue> expression without " +
+				"braces surrounding <queue>. Braces are required by the LRM, " +
+				"but some simulators support a relaxed interpretation");
+		fShortDescMap.put(ALLOW_INSIDE_Q_WITHOUT_BRACES,
+				"Allow <field> inside <queue> expression without braces");
+	}
+	
+	public static Map<String, String> getDescMap() {
+		return fDescMap;
+	}
+	
+	public static Set<String> getOptionSet() {
+		return fDescMap.keySet();
+	}
+	
+	public static String getShortDesc(String option) {
+		return fShortDescMap.get(option);
+	}
+	
+	public String getDesc(String option) {
+		return fDescMap.get(option);
+	}
+
+	/**
+	 * Enables the parser to recognize a statement of the form:
+	 * 
+	 * if (a inside q)
+	 * 
+	 * where q is a queue. The LRM-compliant code is:
+	 * 
+	 * if (a inside {q})
+	 * 
+	 * VCS appears to allow the first form of the statement.
+	 */
+	private boolean					fAllowInsideQWithoutBraces = false;
+	
+	
+	public boolean allowInsideQWithoutBraces() {
+		return fAllowInsideQWithoutBraces;
+	}
+	
+	public void setAllowInsideQWithoutBraces(boolean a) {
+		fAllowInsideQWithoutBraces = a;
+	}
+	
+	public void setOption(String option, boolean en) {
+		if (option.equals(ALLOW_INSIDE_Q_WITHOUT_BRACES)) {
+			setAllowInsideQWithoutBraces(en);
+		}
+	}
+
+}

--- a/sveditor/plugins/net.sf.sveditor.ui/plugin.xml
+++ b/sveditor/plugins/net.sf.sveditor.ui/plugin.xml
@@ -684,6 +684,12 @@
             id="net.sf.sveditor.ui.indexPreferences"
             name="Index Preferences">
       </page>
+      <page
+            category="net.sf.sveditor.ui.page1"
+            class="net.sf.sveditor.ui.pref.SVEditorCodeStylePrefsPage"
+            id="net.sf.sveditor.ui.svEditorCodeStylePrefs"
+            name="Code Style Preferences">
+      </page>
    </extension>
    <extension
          point="org.eclipse.core.runtime.preferences">

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/SVUiPlugin.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/SVUiPlugin.java
@@ -21,6 +21,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
 import java.util.WeakHashMap;
+import java.util.Map.Entry;
 
 import net.sf.sveditor.core.SVCorePlugin;
 import net.sf.sveditor.core.XMLTransformUtils;
@@ -29,6 +30,7 @@ import net.sf.sveditor.core.log.ILogHandle;
 import net.sf.sveditor.core.log.ILogLevel;
 import net.sf.sveditor.core.log.ILogListener;
 import net.sf.sveditor.core.log.LogFactory;
+import net.sf.sveditor.core.parser.SVParserConfig;
 import net.sf.sveditor.core.templates.IExternalTemplatePathProvider;
 import net.sf.sveditor.core.templates.ITemplateParameterProvider;
 import net.sf.sveditor.core.templates.TemplateParameterProvider;
@@ -132,6 +134,8 @@ public class SVUiPlugin extends AbstractUIPlugin
 					getPreferenceStore().getString(SVEditorPrefsConstants.P_DEBUG_LEVEL_S)));
 			SVCorePlugin.getDefault().getSVDBIndexRegistry().setEnableAutoRebuild(
 					getPreferenceStore().getBoolean(SVEditorPrefsConstants.P_AUTO_REBUILD_INDEX));
+	
+			update_parser_prefs();
 		}
 		
 		TemplateRegistry rgy = SVCorePlugin.getDefault().getTemplateRgy();
@@ -164,6 +168,20 @@ public class SVUiPlugin extends AbstractUIPlugin
 		if (params != null) {
 			fGlobalPrefsProvider = new TemplateParameterProvider(params);
 		}
+	}
+	
+	private void update_parser_prefs() {
+		try {
+			Map<String, String> parser_opts = XMLTransformUtils.xml2Map(
+					getPreferenceStore().getString(SVEditorPrefsConstants.P_SV_CODE_STYLE_PREFS),
+					"preferences", "preference");
+		
+			SVParserConfig cfg = SVCorePlugin.getDefault().getParserConfig();
+			for (Entry<String, String> entry : parser_opts.entrySet()) {
+				cfg.setOption(entry.getKey(), entry.getValue().equals("true"));
+			}
+		} catch (Exception e) {}
+		
 	}
 	
 	public List<String> getExternalTemplatePath() {
@@ -260,6 +278,8 @@ public class SVUiPlugin extends AbstractUIPlugin
 					(Boolean)event.getNewValue());
 		} else if (event.getProperty().equals(SVEditorPrefsConstants.P_SV_TEMPLATE_PROPERTIES)) {
 			update_global_parameters();
+		} else if (event.getProperty().equals(SVEditorPrefsConstants.P_SV_CODE_STYLE_PREFS)) {
+			update_parser_prefs();
 		}
 	}
 	

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorCodeStylePrefsPage.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorCodeStylePrefsPage.java
@@ -1,0 +1,169 @@
+package net.sf.sveditor.ui.pref;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.sf.sveditor.core.XMLTransformUtils;
+import net.sf.sveditor.core.parser.SVParserConfig;
+import net.sf.sveditor.ui.SVUiPlugin;
+
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.CheckStateChangedEvent;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.ICheckStateListener;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class SVEditorCodeStylePrefsPage extends PreferencePage implements
+		IWorkbenchPreferencePage {
+	
+	private Map<String, String>				fOptionValMap;
+	private List<String>					fOptionNames;
+	private CheckboxTableViewer				fTableViewer;
+	private Text							fDescription;
+
+	public SVEditorCodeStylePrefsPage() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public SVEditorCodeStylePrefsPage(String title) {
+		super(title);
+	}
+
+	public SVEditorCodeStylePrefsPage(String title, ImageDescriptor image) {
+		super(title, image);
+	}
+
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(SVUiPlugin.getDefault().getPreferenceStore());
+		
+		fOptionValMap = new HashMap<String, String>();
+		fOptionNames = new ArrayList<String>();
+		
+		fOptionNames.addAll(SVParserConfig.getOptionSet());
+		
+		String pref = getPreferenceStore().getString(SVEditorPrefsConstants.P_SV_CODE_STYLE_PREFS);
+		
+		try {
+			Map<String, String> map = 
+				XMLTransformUtils.xml2Map(pref, "preferences", "preference");
+			for (String name : fOptionNames) {
+				fOptionValMap.put(name, 
+						"" + (map.containsKey(name) && map.get(name).equals("true")));
+			}
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected Control createContents(Composite parent) {
+		Composite	frame = new Composite(parent, SWT.NONE);
+		frame.setLayout(new GridLayout());
+		frame.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
+		Group upper_group = new Group(frame, SWT.FLAT);
+		upper_group.setLayout(new GridLayout());
+		upper_group.setText("Code Style Options");
+		upper_group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
+		fTableViewer = CheckboxTableViewer.newCheckList(upper_group, SWT.WRAP);
+
+		fTableViewer.getTable().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		fTableViewer.setContentProvider(fContentProvider);
+		fTableViewer.setLabelProvider(fLabelProvider);
+		fTableViewer.addCheckStateListener(new ICheckStateListener() {
+			public void checkStateChanged(CheckStateChangedEvent event) {
+				fOptionValMap.remove(event.getElement());
+				fOptionValMap.put((String)event.getElement(), "" + event.getChecked());
+			}
+		});
+		
+		fTableViewer.addSelectionChangedListener(new ISelectionChangedListener() {
+			
+			public void selectionChanged(SelectionChangedEvent event) {
+				IStructuredSelection sel = (IStructuredSelection)event.getSelection();
+				String option = (String)sel.getFirstElement();
+				fDescription.setText(SVParserConfig.getDescMap().get(option));
+			}
+		});
+		
+		
+		Group bottom_group = new Group(frame, SWT.FLAT);
+		bottom_group.setText("Description");
+		bottom_group.setLayout(new GridLayout());
+		bottom_group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
+		fDescription = new Text(bottom_group, SWT.READ_ONLY+SWT.MULTI+SWT.WRAP);
+		fDescription.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		
+		fTableViewer.setInput(fOptionNames);
+		
+		for (Entry<String, String> entry : fOptionValMap.entrySet()) {
+			fTableViewer.setChecked(entry.getKey(), entry.getValue().equals("true"));
+		}
+		
+		return frame;
+	}
+	
+	private void applyConfig() {
+		
+		try {
+			String val = XMLTransformUtils.map2Xml(fOptionValMap, 
+				"preferences", "preference");
+			getPreferenceStore().setValue(SVEditorPrefsConstants.P_SV_CODE_STYLE_PREFS, val);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected void performApply() {
+		applyConfig();
+	}
+
+	@Override
+	public boolean performOk() {
+		applyConfig();
+		return true;
+	}
+
+	private IStructuredContentProvider 				fContentProvider = new IStructuredContentProvider() {
+		
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) { }
+		
+		public void dispose() { }
+		
+		public Object[] getElements(Object inputElement) {
+			return fOptionNames.toArray();
+		}
+	};
+	
+	private ILabelProvider						fLabelProvider = new LabelProvider() {
+
+		@Override
+		public String getText(Object element) {
+			return SVParserConfig.getShortDesc((String)element);
+		}
+	};
+	
+}

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorPrefsConstants.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorPrefsConstants.java
@@ -78,5 +78,7 @@ public class SVEditorPrefsConstants {
 	public static final String P_OUTLINE_SHOW_COVER_POINT_GROUP_CROSS           	= OUTLINE_SETTINGS + "outlineShowCoverPointGroupCross";
 	public static final String P_OUTLINE_SHOW_CONSTRAINTS                       	= OUTLINE_SETTINGS + "outlineShowConstraints";
 	public static final String P_OUTLINE_SORT                                   	= OUTLINE_SETTINGS + "outlineSort";
-	
+
+	// Code Style Preferences
+	public static final String P_SV_CODE_STYLE_PREFS								= INDEX_SETTINGS + "codeStylePrefs";
 }

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorPrefsInitialize.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/pref/SVEditorPrefsInitialize.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.sf.sveditor.core.XMLTransformUtils;
+import net.sf.sveditor.core.parser.SVParserConfig;
 import net.sf.sveditor.core.templates.DefaultTemplateParameterProvider;
 import net.sf.sveditor.ui.SVUiPlugin;
 import net.sf.sveditor.ui.editor.SVEditorColors;
@@ -92,6 +93,20 @@ public class SVEditorPrefsInitialize extends AbstractPreferenceInitializer {
 			try {
 				store.setDefault(SVEditorPrefsConstants.P_SV_TEMPLATE_PROPERTIES,
 						XMLTransformUtils.map2Xml(p, "parameters", "parameter"));
+			} catch (Exception e) {}
+		}
+		
+		/**
+		 * Initialize code-style preferences
+		 */
+		{
+			Map<String, String> map = new HashMap<String, String>();
+			for (String key : SVParserConfig.getOptionSet()) {
+				map.put(key, "false");
+			}
+			try {
+				String val = XMLTransformUtils.map2Xml(map, "preferences", "preference");
+				store.setDefault(SVEditorPrefsConstants.P_SV_CODE_STYLE_PREFS, val);
 			} catch (Exception e) {}
 		}
 	}


### PR DESCRIPTION
# (247) - Support this case (if (a inside b)) as a non-LRM-compliant case. Added an extensible

  preference scheme to allow the user to selectively enable non-LRM cases.
