### PR TITLE
Correct parse error with named-mapped class parameters in type expression

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,10 @@
 
 -- 1.2.0 Release --
 
+- #(nobug) - Correct parse error with named-mapped parameters to
+  class type in function call. Eg: foo = my_class #(.A(5), .B(int))::type_id::create();
+  
+
 ------------------------------------------------------------------------------
 -- 1.1.9 Release --
 

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseClassBodyItems.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseClassBodyItems.java
@@ -175,7 +175,21 @@ public class TestParseClassBodyItems extends TestCase {
 				new String[] {"my_class"});
 	}
 	
-
+	public void testNameMappedParamClassCall() {
+		String content = 
+				"class my_class;\n" +
+				"	function void doit();\n" +
+				"		foo = myclass #(.A(5), .B(int))::type_id::create();\n" +
+				"	endfunction\n" +
+				"\n" +
+				"endclass\n" +
+				"\n";
+		SVCorePlugin.getDefault().enableDebug(true);
+		
+		runTest(getName(), content, 
+				new String[] {"my_class", "doit"});
+	}
+	
 	public void testAttrInstance() {
 		String content = 
 			"(*attr1=\"foo\", attr2=bar*)\n" +

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/expr/SVDBParamIdExpr.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/expr/SVDBParamIdExpr.java
@@ -16,9 +16,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.sveditor.core.db.SVDBItemType;
+import net.sf.sveditor.core.db.SVDBParamValueAssignList;
 
 public class SVDBParamIdExpr extends SVDBIdentifierExpr {
-	public List<SVDBExpr>				fParamExpr;
+	public SVDBParamValueAssignList		fParamExpr;
 	
 	public SVDBParamIdExpr() {
 		this(null);
@@ -26,15 +27,14 @@ public class SVDBParamIdExpr extends SVDBIdentifierExpr {
 
 	public SVDBParamIdExpr(String id) {
 		super(SVDBItemType.ParamIdExpr, id);
-		fParamExpr = new ArrayList<SVDBExpr>();
 	}
 
-	public List<SVDBExpr> getParamExpr() {
+	public SVDBParamValueAssignList getParamExpr() {
 		return fParamExpr;
 	}
 	
-	public void addParamExpr(SVDBExpr expr) {
-		fParamExpr.add(expr);
+	public void setParamExpr(SVDBParamValueAssignList plist) {
+		fParamExpr = plist;
 	}
 	
 }

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprUtilsParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprUtilsParser.java
@@ -12,6 +12,7 @@
 
 package net.sf.sveditor.core.expr_utils;
 
+import net.sf.sveditor.core.SVCorePlugin;
 import net.sf.sveditor.core.log.ILogHandle;
 import net.sf.sveditor.core.log.LogFactory;
 import net.sf.sveditor.core.log.LogHandle;
@@ -87,7 +88,7 @@ public class SVExprUtilsParser implements ISVParser {
 	}
 	
 	public SVParserConfig getConfig() {
-		return null;
+		return SVCorePlugin.getDefault().getParserConfig();
 	}
 
 	public void debug(String msg, Exception e) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ParserSVDBFileFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/ParserSVDBFileFactory.java
@@ -287,39 +287,7 @@ public class ParserSVDBFileFactory implements ISVScanner,
 		return ret;
 	}
 
-	/**
-	 * Tries to read a scoped static identifier list
-	 * 
-	 * @param allow_keywords
-	 * @return
-	 * @throws SVParseException
-	 */
-	public List<SVToken> peekScopedStaticIdentifier_l(boolean allow_keywords) throws SVParseException {
-		List<SVToken> ret = new ArrayList<SVToken>();
 
-		if (!allow_keywords) {
-			if (fLexer.peekId()) {
-				ret.add(fLexer.readIdTok());
-			} else {
-				return ret;
-			}
-		} else if (fLexer.peekKeyword() || fLexer.peekId()) {
-			ret.add(fLexer.consumeToken());
-		} else {
-			return ret;
-		}
-
-		while (fLexer.peekOperator("::")) {
-			ret.add(fLexer.consumeToken());
-			if (allow_keywords && fLexer.peekKeyword()) {
-				ret.add(fLexer.consumeToken());
-			} else {
-				ret.add(fLexer.readIdTok());
-			}
-		}
-
-		return ret;
-	}
 
 	public String scopedIdentifierList2Str(List<SVToken> scoped_id) {
 		StringBuilder sb = new StringBuilder();

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVCommonParserUtils.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVCommonParserUtils.java
@@ -1,0 +1,45 @@
+package net.sf.sveditor.core.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SVCommonParserUtils extends SVParserBase {
+	
+	public SVCommonParserUtils(ISVParser parser) {
+		super(parser);
+	}
+
+	/**
+	 * Tries to read a scoped static identifier list
+	 * 
+	 * @param allow_keywords
+	 * @return
+	 * @throws SVParseException
+	 */
+	public List<SVToken> peekScopedStaticIdentifier_l(boolean allow_keywords) throws SVParseException {
+		List<SVToken> ret = new ArrayList<SVToken>();
+
+		if (!allow_keywords) {
+			if (fLexer.peekId()) {
+				ret.add(fLexer.readIdTok());
+			} else {
+				return ret;
+			}
+		} else if (fLexer.peekKeyword() || fLexer.peekId()) {
+			ret.add(fLexer.consumeToken());
+		} else {
+			return ret;
+		}
+
+		while (fLexer.peekOperator("::")) {
+			ret.add(fLexer.consumeToken());
+			if (allow_keywords && fLexer.peekKeyword()) {
+				ret.add(fLexer.consumeToken());
+			} else {
+				ret.add(fLexer.readIdTok());
+			}
+		}
+
+		return ret;
+	}
+}

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.Stack;
 
 import net.sf.sveditor.core.db.SVDBLocation;
+import net.sf.sveditor.core.db.SVDBParamValueAssignList;
 import net.sf.sveditor.core.db.SVDBTypeInfo;
 import net.sf.sveditor.core.db.expr.SVCoverageExpr;
 import net.sf.sveditor.core.db.expr.SVDBArrayAccessExpr;
@@ -1124,10 +1125,18 @@ public class SVExprParser extends SVParserBase {
 					}
 					// Parameterized identifier
 					ret = new SVDBParamIdExpr(id);
+					/*
 					fLexer.eatToken(); // #
 					fLexer.readOperator("(");
+					 */
 					// Catch case where no parameters are specified in the parameter list
+					boolean name_mapped = false;
+					SVDBParamValueAssignList plist = parsers().paramValueAssignParser().parse(true);
+					
+
+					/**
 					while (fLexer.peek() != null && !fLexer.peekOperator(")")) {
+						// TODO: should preserve the 
 						((SVDBParamIdExpr)ret).addParamExpr(datatype_or_expression());
 						if (fLexer.peekOperator(",")) {
 							fLexer.eatToken();
@@ -1136,6 +1145,7 @@ public class SVExprParser extends SVParserBase {
 						}
 					}
 					fLexer.readOperator(")");
+					 */
 				} else if (fLexer.peekOperator("(") || fLexer.peekKeyword("with")) {
 					if (id.equals("randomize")) {
 						ret = randomize_call(null);

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParameterValueAssignmentParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParameterValueAssignmentParser.java
@@ -75,7 +75,7 @@ public class SVParameterValueAssignmentParser extends SVParserBase {
 					ret.addParameter(new SVDBParamValueAssign(name, new SVDBNullExpr()));
 				}
 				else if (!fLexer.peekOperator(")")) {
-					List<SVToken> id_list = parsers().SVParser().peekScopedStaticIdentifier_l(false);
+					List<SVToken> id_list = parsers().commonParserUtils().peekScopedStaticIdentifier_l(false);
 
 					if (fLexer.peekOperator("#") /*|| fLexer.peekKeyword(SVKeywords.fBuiltinTypes) ||
 							fLexer.peekKeyword("virtual") */) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParsers.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVParsers.java
@@ -23,6 +23,7 @@ public class SVParsers {
 	
 	private ISVParser							fSVParser;
 	private ParserSVDBFileFactory				fSVDBFileFactory;
+	private SVCommonParserUtils					fCommonParserUtils;
 	private SVClassDeclParser					fClassParser;
 	private SVCovergroupParser					fCovergroupParser;
 	private SVParameterDeclParser				fParamDeclParser;
@@ -65,6 +66,7 @@ public class SVParsers {
 	
 	public void init(ISVParser parser) {
 		fSVParser = parser;
+		fCommonParserUtils = new SVCommonParserUtils(fSVParser);
 		fClassParser = new SVClassDeclParser(fSVParser);
 		fParamDeclParser = new SVParameterDeclParser(fSVParser);
 		fParamPortParser = new SVParameterPortListParser(fSVParser);
@@ -96,6 +98,10 @@ public class SVParsers {
 	
 	public ParserSVDBFileFactory SVParser() {
 		return fSVDBFileFactory;
+	}
+	
+	public SVCommonParserUtils commonParserUtils() {
+		return fCommonParserUtils;
 	}
 	
 	public final SVClassDeclParser classParser() {


### PR DESCRIPTION
Correct parse error with named-mapped parameters to
  class type in function call. Eg: foo = my_class #(.A(5), .B(int))::type_id::create();
