### PR TITLE
Decl and Hier Hyperlinks enabled for class decls

### DIFF
--- a/sveditor/plugins/net.sf.sveditor.ui/plugin.xml
+++ b/sveditor/plugins/net.sf.sveditor.ui/plugin.xml
@@ -1114,4 +1114,22 @@ endclass
             name="Compilation Arguments">
       </wizard>
    </extension>
+   <extension
+         point="org.eclipse.ui.workbench.texteditor.hyperlinkDetectorTargets">
+      <target
+            id="net.sf.sveditor.ui.svCode"
+            name="SystemVerilog Editor">
+            <context type="org.eclipse.ui.texteditor.ITextEditor"/>
+      </target>
+   </extension>
+   <extension
+         point="org.eclipse.ui.workbench.texteditor.hyperlinkDetectors">
+      <hyperlinkDetector
+            class="net.sf.sveditor.ui.editor.SVElementHyperlinkDetector"
+            id="net.sf.sveditor.ui.editor.SVElementHyperlinkDetector"
+            name="SystemVerilog Elements"
+            targetId="net.sf.sveditor.ui.svCode">
+      </hyperlinkDetector>
+   </extension>
+
 </plugin>

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/compare/SVCompareViewer.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/compare/SVCompareViewer.java
@@ -34,7 +34,7 @@ public class SVCompareViewer extends TextMergeViewer {
 	protected void configureTextViewer(TextViewer textViewer) {
 		if(textViewer instanceof SourceViewer) {
 			SourceViewer viewer = (SourceViewer)textViewer;
-			SVSourceViewerConfiguration configuration = new SVSourceViewerConfiguration(null);
+			SVSourceViewerConfiguration configuration = new SVSourceViewerConfiguration(null,null);
 			viewer.configure(configuration);
 		}
 	}

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVEditor.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVEditor.java
@@ -104,6 +104,7 @@ import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.editors.text.ITextEditorHelpContextIds;
 import org.eclipse.ui.editors.text.TextEditor;
+import org.eclipse.ui.editors.text.TextSourceViewerConfiguration;
 import org.eclipse.ui.ide.IDEActionFactory;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.texteditor.AddTaskAction;
@@ -736,7 +737,8 @@ public class SVEditor extends TextEditor
 	}
 
 	public void createPartControl(Composite parent) {
-		setSourceViewerConfiguration(new SVSourceViewerConfiguration(this));
+		
+		setSourceViewerConfiguration(new SVSourceViewerConfiguration(this,SVUiPlugin.getDefault().getPreferenceStore()));
 		
 		super.createPartControl(parent);
 		

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVElementHyperlink.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVElementHyperlink.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Armond Paiva - repurposed from JDT for use in SVEditor
+ *******************************************************************************/
+
+package net.sf.sveditor.ui.editor;
+
+import net.sf.sveditor.core.db.ISVDBItemBase;
+
+import org.eclipse.core.runtime.Assert;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+
+/**
+ * SV element hyperlink.
+ *
+ * 
+ */
+public class SVElementHyperlink implements IHyperlink {
+
+	private final IRegion fRegion;
+	@SuppressWarnings("unused")
+	private final ISVDBItemBase fElement;
+	@SuppressWarnings("unused")
+	private final boolean fQualify;
+	private final Action fAction;
+	private final String fLabel;
+
+	public SVElementHyperlink(IRegion region, Action action, ISVDBItemBase element, boolean qualify, String label) {
+		
+		Assert.isNotNull(label) ;
+		Assert.isNotNull(region) ;
+		Assert.isNotNull(action) ;
+
+		fRegion 	= region ;
+		fElement	= element ;
+		fQualify	= qualify ;
+		fAction 	= action ;
+		fLabel 		= label ;
+	}
+
+	public IRegion getHyperlinkRegion() {
+		return fRegion;
+	}
+
+	public void open() {
+		if(fAction != null) fAction.run() ;
+	}
+
+	public String getTypeLabel() {
+		return fLabel;
+	}
+
+	public String getHyperlinkText() {
+		return fLabel ;
+	}
+}

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVElementHyperlinkDetector.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVElementHyperlinkDetector.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Armond Paiva - repurposed from JDT for use in SVEditor
+ *******************************************************************************/
+package net.sf.sveditor.ui.editor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import net.sf.sveditor.core.db.ISVDBItemBase;
+import net.sf.sveditor.core.log.LogFactory;
+import net.sf.sveditor.core.log.LogHandle;
+import net.sf.sveditor.core.log.ILogLevel;
+import net.sf.sveditor.ui.SVUiPlugin;
+import net.sf.sveditor.ui.editor.actions.OpenDeclarationAction;
+import net.sf.sveditor.ui.editor.actions.OpenTypeHierarchyAction;
+import net.sf.sveditor.ui.editor.actions.SelectionConverter;
+import net.sf.sveditor.ui.text.SVWordFinder;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.hyperlink.AbstractHyperlinkDetector;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+
+public class SVElementHyperlinkDetector extends AbstractHyperlinkDetector implements ILogLevel {
+	
+	private LogHandle	fLog ;
+	
+	public SVElementHyperlinkDetector() {
+		fLog = LogFactory.getLogHandle("ElementHyperlinkDetector") ;
+	}
+
+	public IHyperlink[] detectHyperlinks(ITextViewer textViewer, IRegion region, boolean canShowMultipleHyperlinks) {
+		
+		ITextEditor textEditor= (ITextEditor)getAdapter(ITextEditor.class) ;
+		
+		if (region == null || !(textEditor instanceof SVEditor)) return null;
+		
+		SVEditor editor = (SVEditor)textEditor ;
+		
+		int offset= region.getOffset();
+		
+		fLog.debug(LEVEL_MIN, "Detecting hyperlinks") ;
+		
+		ISVDBItemBase item = SelectionConverter.getElementAt(editor, offset) ;
+		
+		if(item == null) {
+			return null ;
+		}
+		
+		IDocumentProvider documentProvider= editor.getDocumentProvider();
+		IEditorInput editorInput= editor.getEditorInput();
+		IDocument document= documentProvider.getDocument(editorInput);
+		IRegion wordRegion = SVWordFinder.findWord(document, offset) ;
+		
+		return createHyperLinks(editor, item, wordRegion) ;
+		
+		
+	}
+	
+	private IHyperlink[] createHyperLinks(SVEditor editor, ISVDBItemBase item, IRegion wordRegion) {
+		
+		List<IHyperlink> links = new ArrayList<IHyperlink>() ;
+		
+		ResourceBundle bundle = SVUiPlugin.getDefault().getResources() ;
+		
+		fLog.debug(LEVEL_MIN, "Creating links for type(" + item.getType() + ")") ;
+		
+		switch(item.getType()) {
+			case ClassDecl:
+				// open decl
+				Action action = new OpenDeclarationAction(bundle, editor) ;
+				links.add(new SVElementHyperlink(wordRegion, action, item, false, "Open Declaration")) ;
+				// open hierarchy
+				action = new OpenTypeHierarchyAction(bundle, editor) ;
+				links.add(new SVElementHyperlink(wordRegion, action, item, false, "Open Type Hierarchy")) ;
+				break ;
+			default:
+		}
+		
+		
+		if(links.isEmpty()) {
+			return null ;
+		} else {
+			return links.toArray(new IHyperlink[links.size()]) ;
+		}
+
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+	}
+
+
+}

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVSourceViewerConfiguration.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVSourceViewerConfiguration.java
@@ -15,6 +15,7 @@ package net.sf.sveditor.ui.editor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import net.sf.sveditor.ui.SVUiPlugin;
 import net.sf.sveditor.ui.pref.SVEditorPrefsConstants;
@@ -26,6 +27,7 @@ import net.sf.sveditor.ui.text.SVElementProvider;
 import net.sf.sveditor.ui.text.hover.ISVEditorTextHover;
 import net.sf.sveditor.ui.text.hover.SVDocHover;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.text.AbstractInformationControlManager;
@@ -52,17 +54,19 @@ import org.eclipse.jface.text.rules.Token;
 import org.eclipse.jface.text.source.DefaultAnnotationHover;
 import org.eclipse.jface.text.source.IAnnotationHover;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.jface.text.source.SourceViewerConfiguration;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.editors.text.EditorsUI;
+import org.eclipse.ui.editors.text.TextSourceViewerConfiguration;
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 
-public class SVSourceViewerConfiguration extends SourceViewerConfiguration {
+public class SVSourceViewerConfiguration extends TextSourceViewerConfiguration {
 	private SVEditor				fEditor;
 	private ContentAssistant		fContentAssist;
 	
-	public SVSourceViewerConfiguration(SVEditor editor) {
+	public SVSourceViewerConfiguration(SVEditor editor, IPreferenceStore iPreferenceStore) {
+		super(EditorsUI.getPreferenceStore()) ;
 		fEditor = editor;
 	}
 	
@@ -96,7 +100,6 @@ public class SVSourceViewerConfiguration extends SourceViewerConfiguration {
 					IDocument.DEFAULT_CONTENT_TYPE);
 			fContentAssist.setInformationControlCreator(
 					getContentAssistPresenterControlCreator(sourceViewer));
-//					getInformationControlCreator(sourceViewer));
 			fContentAssist.enableAutoActivation(true);
 			fContentAssist.enableAutoInsert(true);
 			fContentAssist.enablePrefixCompletion(true);
@@ -357,4 +360,11 @@ public class SVSourceViewerConfiguration extends SourceViewerConfiguration {
 		return presenter;
 	}	
 	
+    @Override
+    protected Map<String, IAdaptable> getHyperlinkDetectorTargets(ISourceViewer sourceViewer) {
+            Map<String, IAdaptable> targets= super.getHyperlinkDetectorTargets(sourceViewer);
+            targets.put("net.sf.sveditor.ui.svCode", fEditor); //$NON-NLS-1$
+            return targets;
+    }
+
 }

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/text/HierarchyInformationControl.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/text/HierarchyInformationControl.java
@@ -9,8 +9,7 @@ package net.sf.sveditor.ui.text;
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *     Armond Paiva - repurposed from JDT for SVEditor Objects Quick View
- *     Armond Paiva - repurposed from Objects Quick View to Outline Quick View
+ *     Armond Paiva - repurposed from JDT
  *******************************************************************************/
 
 import net.sf.sveditor.core.db.ISVDBItemBase;


### PR DESCRIPTION
Adds in-editor hyperlink mechanism similar to that in JDT.  

Only enabled for classes.  Ctrl+MouseOver a class name, and it becomes hyperlinked with an option to open the declaration or hierarchy.

Can be enabled/disabled in the general text editor properties under hyperlinking.
