### PR TITLE
Add support for the '-sv' and '-sverilog' switches

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,7 +12,11 @@
   after initial processing of an include file, subsequent inclusions of 
   that file simply bring in the macros previously defined.
   
+- #(nobug) - Correct a line-number issue with the 'new' index. `ifdef/`ifndef
+  directives caused the line number to incorrectly be incremented  
   
+- #(275) - Add support for the '-sv' and '-sverilog' switches to force all 
+  files in the argument-file tree to be processed as SystemVerilog files.
 
 ------------------------------------------------------------------------------
 -- 1.3.6 Release --

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/index/TestArgFileIndex.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/index/TestArgFileIndex.java
@@ -483,4 +483,29 @@ public class TestArgFileIndex extends SVCoreTestCaseBase {
 		assertEquals(0, CoreReleaseTests.getErrors().size());
 		LogFactory.removeLogHandle(log);
 	}	
+	
+	public void testMixedSvVlogOverride() throws IOException {
+		String testname = getName();
+		CoreReleaseTests.clearErrors();
+		BundleUtils utils = new BundleUtils(SVCoreTestsPlugin.getDefault().getBundle());
+
+		SVCorePlugin.getDefault().enableDebug(false);
+		
+		final IProject project_dir = TestUtils.createProject(testname);
+		
+		String data_root = "/data/index/change_src_levels/";
+		utils.copyBundleDirToWS(data_root, project_dir);
+		
+		SVDBIndexRegistry rgy = SVCorePlugin.getDefault().getSVDBIndexRegistry();
+		
+		ISVDBIndex index = rgy.findCreateIndex(new NullProgressMonitor(), "GENERIC", 
+				"${workspace_loc}/" + testname + "/change_src_levels/change_src_levels.f", 
+				SVDBArgFileIndexFactory.TYPE, null);
+		index.execIndexChangePlan(new NullProgressMonitor(), new SVDBIndexChangePlanRebuild(index));
+	
+		IndexTestUtils.assertNoErrWarn(fLog, index);
+		IndexTestUtils.assertFileHasElements(index, "file1_pkg", "file2_pkg");
+		
+		assertEquals(0, CoreReleaseTests.getErrors().size());
+	}
 }

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/index/TestCrossIndexReferences.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/index/TestCrossIndexReferences.java
@@ -86,14 +86,16 @@ public class TestCrossIndexReferences extends SVCoreTestCaseBase {
 		p1_pdata.setProjectFileWrapper(p1_fwrapper);
 		p2_pdata.setProjectFileWrapper(p2_fwrapper);
 	
-		/* SVDBIndexCollection p1_index = */ p1_pdata.getProjectIndexMgr();
+		SVDBIndexCollection p1_index = p1_pdata.getProjectIndexMgr();
 		SVDBIndexCollection p2_index = p2_pdata.getProjectIndexMgr();
+		p1_index.loadIndex(new NullProgressMonitor());
 		p2_index.loadIndex(new NullProgressMonitor());
 	
 		IndexTestUtils.assertFileHasElements(fLog, p2_index, "p1_c");
 	}
 	
 	public void testCircularArgFileIndexCrossRef() throws CoreException {
+		SVCorePlugin.getDefault().enableDebug(true);
 		SVDBProjectManager pmgr = SVCorePlugin.getDefault().getProjMgr();
 		
 		IProject p1 = TestUtils.setupIndexWSProject(
@@ -125,8 +127,9 @@ public class TestCrossIndexReferences extends SVCoreTestCaseBase {
 		p1_pdata.setProjectFileWrapper(p1_fwrapper);
 		p2_pdata.setProjectFileWrapper(p2_fwrapper);
 	
-		/* SVDBIndexCollection p1_index = */ p1_pdata.getProjectIndexMgr();
+		SVDBIndexCollection p1_index = p1_pdata.getProjectIndexMgr();
 		SVDBIndexCollection p2_index = p2_pdata.getProjectIndexMgr();
+		p1_index.loadIndex(new NullProgressMonitor());
 		p2_index.loadIndex(new NullProgressMonitor());
 		
 		IndexTestUtils.assertFileHasElements(fLog, p2_index, "p1_c");
@@ -164,8 +167,9 @@ public class TestCrossIndexReferences extends SVCoreTestCaseBase {
 		p1_pdata.setProjectFileWrapper(p1_fwrapper);
 		p2_pdata.setProjectFileWrapper(p2_fwrapper);
 	
-		/* SVDBIndexCollection p1_index = */ p1_pdata.getProjectIndexMgr();
+		SVDBIndexCollection p1_index = p1_pdata.getProjectIndexMgr();
 		SVDBIndexCollection p2_index = p2_pdata.getProjectIndexMgr();
+		p1_index.loadIndex(new NullProgressMonitor());
 		p2_index.loadIndex(new NullProgressMonitor());
 		
 		IndexTestUtils.assertFileHasElements(fLog, p2_index, "p1_c", "p2_c");

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileWriter.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileWriter.java
@@ -73,6 +73,10 @@ public class ArgFileWriter {
 				writeIncFileStmt((SVDBArgFileIncFileStmt)item);
 			} break;
 			
+			case ArgFileForceSvStmt: {
+//				writeForceSvStmt((SVDB))
+			} break;
+			
 			case ArgFileLibExtStmt: {
 				writeLibExtStmt((SVDBArgFileLibExtStmt)item);
 			} break;

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/ISVArgFileOptionProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/ISVArgFileOptionProvider.java
@@ -18,6 +18,7 @@ public interface ISVArgFileOptionProvider {
 		SrcLibExt,			// +libext+.sv+.svh+.vlog
 		MFCU,				// -mfcu
 		SFCU,				// -sfcu
+		SV,					// -sv or -sverilog
 	}
 	
 	OptionType getOptionType(String name);

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileParser.java
@@ -11,6 +11,7 @@ import net.sf.sveditor.core.db.SVDBMarker;
 import net.sf.sveditor.core.db.SVDBMarker.MarkerKind;
 import net.sf.sveditor.core.db.SVDBMarker.MarkerType;
 import net.sf.sveditor.core.db.argfile.SVDBArgFileDefineStmt;
+import net.sf.sveditor.core.db.argfile.SVDBArgFileForceSvStmt;
 import net.sf.sveditor.core.db.argfile.SVDBArgFileIncDirStmt;
 import net.sf.sveditor.core.db.argfile.SVDBArgFileIncFileStmt;
 import net.sf.sveditor.core.db.argfile.SVDBArgFileMfcuStmt;
@@ -232,6 +233,13 @@ public class SVArgFileParser {
 							stmt.setSrcLibFile(path);
 							file.addChildItem(stmt);
 							} break;
+							
+						case SV: {
+							SVDBArgFileForceSvStmt stmt = new SVDBArgFileForceSvStmt();
+							stmt.setLocation(fLexer.getStartLocation());
+							
+							file.addChildItem(stmt);
+						} break;
 							
 						default:
 							error(tok.getStartLocation(), "Unrecognized option type " + type);

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileQuestaOptionProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileQuestaOptionProvider.java
@@ -149,6 +149,8 @@ public class SVArgFileQuestaOptionProvider implements ISVArgFileOptionProvider {
 			return OptionType.SrcLibFile;
 		} else if (name.equals("-mfcu")) {
 			return OptionType.MFCU;
+		} else if (name.equals("-sv")) {
+			return OptionType.SV;
 		} else if (fOptions.containsKey(name)) {
 			return OptionType.Ignored;
 		} else {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileVCSOptionProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/parser/SVArgFileVCSOptionProvider.java
@@ -28,6 +28,8 @@ public class SVArgFileVCSOptionProvider implements ISVArgFileOptionProvider {
 			return OptionType.SrcLibPath;
 		} else if (name.equals("-v")) {
 			return OptionType.SrcLibFile;
+		} else if (name.equals("-sverilog")) {
+			return OptionType.SV;
 		} else if (fOptions.containsKey(name)) {
 			return OptionType.Ignored;
 		} else {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBFileTree.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBFileTree.java
@@ -164,6 +164,10 @@ public class SVDBFileTree extends SVDBItemBase implements ISVDBChildItem {
 		}
 	}
 	
+	public List<SVDBMarker> getMarkers() {
+		return fMarkers;
+	}
+	
 	public void addIncludedFileTree(SVDBFileTree ft) {
 		fIncludedFileTrees.add(ft);
 		fMacroSetList.add(new SVDBFileTreeMacroList());

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBItemType.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBItemType.java
@@ -203,8 +203,9 @@ public enum SVDBItemType {
 	ArgFileIncDirStmt,
 	ArgFilePathStmt,
 	ArgFileDefineStmt,
+	ArgFileForceSvStmt,
 	ArgFileIncFileStmt,
-	ArgFileMfcuStmt,	
+	ArgFileMfcuStmt,
 	ArgFileSrcLibPathStmt,
 	ArgFileSrcLibFileStmt,
 	ArgFileLibExtStmt	

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBMarker.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/SVDBMarker.java
@@ -45,6 +45,15 @@ public class SVDBMarker extends SVDBItemBase {
 		fMessage 	= message;
 	}
 	
+	public SVDBMarker(
+			MarkerType		type,
+			MarkerKind		kind,
+			String 			message,
+			SVDBLocation	loc) {
+		this(type, kind, message);
+		setLocation(loc);
+	}
+	
 	public MarkerType getMarkerType() {
 		return fMarkerType;
 	}
@@ -80,8 +89,12 @@ public class SVDBMarker extends SVDBItemBase {
 		if (obj instanceof SVDBMarker) {
 			SVDBMarker o = (SVDBMarker)obj;
 			boolean ret = super.equals(obj);
-			
+
+			ret &= (o.fMarkerType == fMarkerType);
 			ret &= (o.fKind == fKind);
+			ret &= o.fMessage.equals(fMessage);
+			
+			ret &= o.fLocation.equals(fLocation);
 			
 			return ret;
 		}

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/argfile/SVDBArgFileForceSvStmt.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/argfile/SVDBArgFileForceSvStmt.java
@@ -1,0 +1,11 @@
+package net.sf.sveditor.core.db.argfile;
+
+import net.sf.sveditor.core.db.SVDBItemType;
+
+public class SVDBArgFileForceSvStmt extends SVDBArgFileStmt {
+	
+	public SVDBArgFileForceSvStmt() {
+		super(SVDBItemType.ArgFileForceSvStmt);
+	}
+
+}

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/SVDBBaseIndexCacheData.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/SVDBBaseIndexCacheData.java
@@ -30,6 +30,7 @@ public class SVDBBaseIndexCacheData {
 	public Map<String, List<SVDBDeclCacheItem>>		fDeclCacheMap;
 	public Map<String, List<SVDBDeclCacheItem>>		fPackageCacheMap;
 	public Map<String, SVDBRefCacheEntry>			fReferenceCacheMap;
+	public boolean									fForceSV;
 
 	public SVDBBaseIndexCacheData(String base) {
 		fBaseLocation = base;

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndex2.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndex2.java
@@ -454,7 +454,13 @@ public class SVDBArgFileIndex2 implements
 				ParserSVDBFileFactory f = new ParserSVDBFileFactory();
 				f.setFileMapper(build_data);
 				
-				SVLanguageLevel language_level = SVLanguageLevel.computeLanguageLevel(path);
+				SVLanguageLevel language_level;
+				
+				if (build_data.getForceSV()) {
+					language_level = SVLanguageLevel.SystemVerilog;
+				} else {
+					language_level = SVLanguageLevel.computeLanguageLevel(path);
+				}
 				List<SVDBMarker> markers = new ArrayList<SVDBMarker>();
 				SVDBFile file = f.parse(language_level, out, path, markers);
 				
@@ -1598,7 +1604,13 @@ public class SVDBArgFileIndex2 implements
 			}
 
 			fLog.debug("--> Parse " + r_path);
-			SVLanguageLevel language_level = SVLanguageLevel.computeLanguageLevel(r_path);
+			SVLanguageLevel language_level;
+			
+			if (fBuildData.getForceSV()) {
+				language_level = SVLanguageLevel.SystemVerilog;
+			} else {
+				language_level = SVLanguageLevel.computeLanguageLevel(r_path);
+			}
 			start = System.currentTimeMillis();
 			file = f.parse(language_level, out, r_path, markers);
 			int file_id = fBuildData.mapFilePathToId(r_path, false);
@@ -2422,6 +2434,9 @@ public class SVDBArgFileIndex2 implements
 					}
 				} else if (ci.getType() == SVDBItemType.ArgFileMfcuStmt) {
 					build_data.setMFCU();
+				} else if (ci.getType() == SVDBItemType.ArgFileForceSvStmt) {
+					System.out.println("ForceSvStmt");
+					build_data.setForceSV(true);
 				} else if (ci.getType() == SVDBItemType.ArgFileSrcLibPathStmt) {
 					SVDBArgFileSrcLibPathStmt stmt = (SVDBArgFileSrcLibPathStmt)ci;
 
@@ -2513,7 +2528,14 @@ public class SVDBArgFileIndex2 implements
 		if (fDebugEn) {
 			fLog.debug(LEVEL_MID, "--> Parse " + path);
 		}
-		SVLanguageLevel language_level = SVLanguageLevel.computeLanguageLevel(path);
+		SVLanguageLevel language_level;
+		
+		if (build_data.getForceSV()) {
+			language_level = SVLanguageLevel.SystemVerilog;
+		} else {
+			language_level = SVLanguageLevel.computeLanguageLevel(path);
+		}
+		
 		SVDBFile file = f.parse(language_level, pp_out, path, markers);
 		long parse_end = System.currentTimeMillis();
 		

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexBuildData.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexBuildData.java
@@ -13,7 +13,6 @@ import net.sf.sveditor.core.Tuple;
 import net.sf.sveditor.core.db.SVDBFile;
 import net.sf.sveditor.core.db.SVDBFileTree;
 import net.sf.sveditor.core.db.SVDBFileTreeMacroList;
-import net.sf.sveditor.core.db.SVDBMacroDef;
 import net.sf.sveditor.core.db.index.ISVDBDeclCache;
 import net.sf.sveditor.core.db.index.ISVDBFileSystemProvider;
 import net.sf.sveditor.core.db.index.SVDBDeclCacheItem;
@@ -128,6 +127,14 @@ public class SVDBArgFileIndexBuildData implements
 	
 	boolean isMFCU() {
 		return fIndexCacheData.fMFCU;
+	}
+	
+	boolean getForceSV() {
+		return fIndexCacheData.fForceSV;
+	}
+	
+	void setForceSV(boolean force) {
+		fIndexCacheData.fForceSV = force;
 	}
 	
 	void addArgFilePath(String path) {

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexCacheData.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexCacheData.java
@@ -40,6 +40,8 @@ public class SVDBArgFileIndexCacheData extends SVDBBaseIndexCacheData {
 	
 	public boolean							fMFCU;
 	
+	public boolean							fForceSV;
+	
 	public SVDBArgFileIndexCacheData(String base_location) {
 		super(base_location);
 		fArgFileTimestamps = new ArrayList<Long>();

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexFactory.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/argfile/SVDBArgFileIndexFactory.java
@@ -24,7 +24,7 @@ public class SVDBArgFileIndexFactory implements ISVDBIndexFactory {
 	
 	public static final String	TYPE = "net.sf.sveditor.argFileIndex";
 	
-	public static final boolean		fUseArgFile2Index = true;
+	public static final boolean		fUseArgFile2Index = false;
 
 	public ISVDBIndex createSVDBIndex(
 			String 					projectName, 

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/old/AbstractSVDBIndex.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/old/AbstractSVDBIndex.java
@@ -1960,7 +1960,13 @@ public abstract class AbstractSVDBIndex implements
 		}
 
 		dp.setMacroProvider(createMacroProvider(file_tree));
-		SVLanguageLevel language_level = SVLanguageLevel.computeLanguageLevel(file_tree.getFilePath());
+		SVLanguageLevel language_level;
+		
+		if (fIndexCacheData.fForceSV) {
+			language_level = SVLanguageLevel.SystemVerilog;
+		} else {
+			language_level = SVLanguageLevel.computeLanguageLevel(file_tree.getFilePath());
+		}
 		SVDBFile svdb_f = factory.parse(language_level, copier.copy(), 
 				file_tree.getFilePath(), markers);
 		
@@ -2021,7 +2027,13 @@ public abstract class AbstractSVDBIndex implements
 			}
 		}
 
-		SVLanguageLevel language_level = SVLanguageLevel.computeLanguageLevel(path.getFilePath());
+		SVLanguageLevel language_level;
+		
+		if (fIndexCacheData.fForceSV) {
+			language_level = SVLanguageLevel.SystemVerilog;
+		} else {
+			language_level = SVLanguageLevel.computeLanguageLevel(path.getFilePath());
+		}
 		SVDBFile svdb_f = factory.parse(language_level, in, path.getFilePath(), markers);
 
 		// Problem parsing the file..

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/old/SVDBArgFileIndex.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/db/index/old/SVDBArgFileIndex.java
@@ -301,6 +301,8 @@ public class SVDBArgFileIndex extends AbstractSVDBIndex {
 						m.setLocation(stmt.getLocation());
 						markers.add(m);
 					}
+				} else if (ci.getType() == SVDBItemType.ArgFileForceSvStmt) {
+					getCacheData().fForceSV = true;
 				}
 			}
 

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/SVPreProc2InputData.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/SVPreProc2InputData.java
@@ -23,7 +23,6 @@ public class SVPreProc2InputData {
 	private int 				fLastCh;
 	private int 				fUngetCh1;
 	private int 				fUngetCh2;
-	private boolean 			fEof;
 	private boolean 			fIncPos;
 	private Map<String, String> fRefMacros;
 	private SVDBFileTree 		fFileTree;
@@ -49,7 +48,6 @@ public class SVPreProc2InputData {
 		fFilename = filename;
 		fFileId   = file_id;
 		fLastCh = -1;
-		fEof = false;
 		fIncPos = inc_pos;
 		fRefMacros = new HashMap<String, String>();
 		fUngetCh1 = -1;
@@ -67,20 +65,19 @@ public class SVPreProc2InputData {
 			try {
 				ch = fInput.read();
 			} catch (IOException e) {}
-		}
-	
-		if (ch != -1) {
-			if (fLastCh == '\n') {
-				if (fIncPos) {
-					// Save a marker for the line in the line map
-					fLineno++;
-					if (fPreProc != null) {
-						fPreProc.add_file_change_info(fFileId, fLineno);
+			if (ch != -1) {
+				if (fLastCh == '\n') {
+					if (fIncPos) {
+						// Save a marker for the line in the line map
+						fLineno++;
+						if (fPreProc != null) {
+							fPreProc.add_file_change_info(fFileId, fLineno);
+						}
 					}
+					fLineCount++;
 				}
-				fLineCount++;
+				fLastCh = ch;
 			}
-			fLastCh = ch;
 		}
 		
 		return ch;

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/svf_scanner/SVFScanner.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/svf_scanner/SVFScanner.java
@@ -39,6 +39,7 @@ public class SVFScanner {
 	private List<String>						fLibPaths;
 	private static Set<String>					fSrcExtensions;
 	private List<String>						fIncludedArgFiles;
+	private boolean								fForceSV;
 	public static final Map<String, Integer>	fIgnoredSwitches;
 	public static final Set<String>			fSupportedSwitches;
 	public static final Set<String>			fRecognizedSwitches;
@@ -135,7 +136,7 @@ public class SVFScanner {
 		fIgnoredSwitches.put("-skipprotected", 0);
 		fIgnoredSwitches.put("-skipprotectedmodule", 0);
 		fIgnoredSwitches.put("-source", 0);
-		fIgnoredSwitches.put("-sv", 0);
+//		fIgnoredSwitches.put("-sv", 0);
 		fIgnoredSwitches.put("-sv05compat", 0);
 		fIgnoredSwitches.put("-sv09compat", 0);
 		fIgnoredSwitches.put("-oldsv", 0);
@@ -211,6 +212,10 @@ public class SVFScanner {
 	
 	public Map<String, String> getDefineMap() {
 		return fDefineMap;
+	}
+	
+	public boolean getForceSV() {
+		return fForceSV;
 	}
 	
 	public void scan(ITextScanner scanner) throws Exception {
@@ -387,6 +392,8 @@ public class SVFScanner {
 					}
 					
 					fLibPaths.add(tmp.toString());
+				} else if (key.equals("-sv") || key.equals("-sverilog")) {
+					fForceSV = true;
 				}
 			} else if (ch == '#') {
 				// Skip preprocessor like lines such as #ifndef, #endif

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVCompletionProcessor.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVCompletionProcessor.java
@@ -149,6 +149,9 @@ public class SVCompletionProcessor extends AbstractCompletionProcessor
 		}
 	
 		List<SVCompletionProposal> temp_p = new ArrayList<SVCompletionProposal>();
+		if (fCompletionProposals == null) {
+			fCompletionProposals = new ArrayList<SVCompletionProposal>();
+		}
 		synchronized (fCompletionProposals) {
 			temp_p.addAll(fCompletionProposals);
 		}


### PR DESCRIPTION
Use of one of these switches forces all  files in the argument-file tree to be processed as SystemVerilog
files.
