### PR TITLE
- #(enh 80) - Add support for code completion of hierarchical references that use macros

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,9 @@
 
 - #(enh) - Change content-assist label provider to display the type name of
   built-in net proposals (eg wire[14:0])
+  
+- #(enh 80) - Add support for code completion of hierarchical references
+  that use macros. For example: `TOP.sub.signal
 
 ------------------------------------------------------------------------------
 -- 1.4.9 Release --

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/content_assist/TestCompletionProcessor.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/content_assist/TestCompletionProcessor.java
@@ -17,11 +17,13 @@ import net.sf.sveditor.core.db.SVDBFile;
 import net.sf.sveditor.core.db.index.ISVDBIndexIterator;
 import net.sf.sveditor.core.log.LogFactory;
 import net.sf.sveditor.core.log.LogHandle;
+import net.sf.sveditor.core.preproc.ISVStringPreProcessor;
 
 public class TestCompletionProcessor extends AbstractCompletionProcessor {
 	
 	private SVDBFile					fSVDBFile;
 	private ISVDBIndexIterator			fIndexIterator;
+	private ISVStringPreProcessor		fPreProcessor;
 	//private boolean						fEnableKeywords;
 	
 	public TestCompletionProcessor(LogHandle log, SVDBFile file, ISVDBIndexIterator iterator) {
@@ -50,6 +52,15 @@ public class TestCompletionProcessor extends AbstractCompletionProcessor {
 	@Override
 	protected SVDBFile getSVDBFile() {
 		return fSVDBFile;
+	}
+
+	@Override
+	protected ISVStringPreProcessor getPreProcessor(int limit_lineno) {
+		return fPreProcessor;
+	}
+
+	public void setPreProcessor(ISVStringPreProcessor preproc) {
+		fPreProcessor = preproc;
 	}
 
 }

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/content_assist/TestContentAssistModule.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/content_assist/TestContentAssistModule.java
@@ -32,6 +32,37 @@ public class TestContentAssistModule extends SVCoreTestCaseBase {
 				"a", "b", "m", "d");
 	}
 	
+	public void testModuleHierarchyRef_1() {
+		SVCorePlugin.getDefault().enableDebug(true);
+		String doc = 
+			"`define TOP top\n" +
+			"module sub2;\n" +
+			"	wire AA;\n" +
+			"	wire BA;\n" +
+			"endmodule\n" +
+			"\n" +
+			"module sub1;\n" +
+			"	sub2	s2_1();\n" +
+			"	sub2	s2_2();\n" +
+			"endmodule\n" +
+			"\n" +
+			"module top;\n" +
+			"	sub1	s1_1();\n" +
+			"	sub1	s1_2();\n" +
+			"endmodule\n" +
+			"\n" +
+			"module m();\n" +
+			"    \n" +
+			"	initial begin\n" +
+			"		`TOP.s1_1.s2_1.A<<MARK>>\n" +
+			"	end\n" +
+			"endmodule\n"
+			;
+
+		ContentAssistTests.runTest(getName(), fCacheFactory, doc, 
+				"AA");		
+	}
+	
 }
 
 

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprScanner.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/expr_utils/SVExprScanner.java
@@ -149,7 +149,7 @@ public class SVExprScanner {
 					ret.fRoot = "include";
 				}
 			}
-		} else {
+		} else { // Not in a string
 			if (SVCharacter.isSVIdentifierPart((c = scanner.get_ch()))) {
 				debug("notInString c=\"" + (char)c + "\"");
 				scanner.unget_ch(c);
@@ -197,7 +197,7 @@ public class SVExprScanner {
 						ret.fType = ContextType.Untriggered;
 					}
 				}
-			} else {
+			} else { // Not an identifier part
 				// backup and try for a triggered identifier
 				debug("notInId: ch=\"" + (char)c + "\"");
 				
@@ -370,7 +370,18 @@ public class SVExprScanner {
 				break;
 			}
 			start_pos = (scanner.getPos()+1);
-		} while ((trigger = readTriggerStr(scanner, false)) != null);
+			trigger = readTriggerStr(scanner, false);
+			
+			if (trigger == null) {
+				break;
+			} else if (trigger.equals("`")) {
+				start_pos = (scanner.getPos()+1);
+				trigger = readTriggerStr(scanner, false);
+				if (trigger == null) {
+					break;
+				}
+			}
+		} while (true); // ((trigger = readTriggerStr(scanner, false)) != null);
 		
 		fLog.debug("<-- readExpression");
 		

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/ISVStringPreProcessor.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/ISVStringPreProcessor.java
@@ -1,0 +1,9 @@
+package net.sf.sveditor.core.preproc;
+
+import java.io.InputStream;
+
+public interface ISVStringPreProcessor {
+	
+	String preprocess(InputStream in);
+
+}

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/scanner/SVPreProcDefineProvider.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/scanner/SVPreProcDefineProvider.java
@@ -30,7 +30,7 @@ import net.sf.sveditor.core.scanutils.ITextScanner;
 import net.sf.sveditor.core.scanutils.StringTextScanner;
 
 public class SVPreProcDefineProvider implements IDefineProvider {
-	private static final boolean		fDebugEn				= true;
+	private static final boolean		fDebugEn				= false;
 	private static final boolean		fDebugChEn				= false;
 	private boolean						fDebugUndefinedMacros	= false;
 	private String						fFilename;


### PR DESCRIPTION
 For example: `TOP.sub.signal
