### PR TITLE
- #(nobug) - Add compilation-argument import support for -mfcu option

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,12 @@
 - #(315) - Correct an issue with the task/function override-annotation
   finding code. In some cases, virtual methods from classes declared in 
   included files would be marked in the active source file.
+  
+- #(nobug) - Add compilation-argument import support for -mfcu option
+
+- #(enh) - During compilation-argument import, add support for executing
+  the commands being intercepted by the compiler wrappers. Sometimes a
+  compilation failure causes the entire process to terminate early.
 
 ------------------------------------------------------------------------------
 -- 1.5.1 Release --

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argcollector/BaseArgCollector.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argcollector/BaseArgCollector.java
@@ -38,8 +38,11 @@ public class BaseArgCollector implements IArgCollector {
 	public void addStderrListener(ILineListener l) {
 		fStderrListener.add(l);
 	}
-	
 	public int process(File cwd, List<String> args) throws IOException {
+		return process(cwd, args, false);
+	}
+	
+	public int process(File cwd, List<String> args, boolean exec) throws IOException {
 		// Create a temp directory
 		fTmpDir = SVCorePlugin.getDefault().createWSTmpDir();
 		
@@ -54,6 +57,7 @@ public class BaseArgCollector implements IArgCollector {
 		EnvUtils env = new EnvUtils();
 		env.setenv("SVE_COMPILER_ARGS_FILE", fOutFile.getAbsolutePath());
 		env.prepend("PATH", sve_collect_compiler_dir.getAbsolutePath());
+		env.setenv("SVE_COMPILER_ARGS_EXEC", (exec)?"1":"0");
 	
 		try {
 			fProcess = Runtime.getRuntime().exec(

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileFilterDuplicates.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileFilterDuplicates.java
@@ -116,7 +116,11 @@ public class ArgFileFilterDuplicates implements IArgFileFilter {
 						eq &= (s1.getSrcLibPath().equals(s2.getSrcLibPath()));
 					}
 				} break;
-				
+			
+				case ArgFileMfcuStmt: 
+				case ArgFileForceSvStmt:
+					break;
+					
 				default: {
 					System.out.println(getClass().getName() + ": Unhandled type " +
 							it1.getType());

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileWriter.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/argfile/filter/ArgFileWriter.java
@@ -89,6 +89,10 @@ public class ArgFileWriter {
 				writeSrcLibPathStmt((SVDBArgFileSrcLibPathStmt)item);
 			} break;
 			
+			case ArgFileMfcuStmt: {
+				fPS.println("-mfcu");
+			} break;
+			
 			default: {
 				fPS.println("// [ERROR] Unknown argument file statement: " + item.getType());
 			}

--- a/sveditor/plugins/net.sf.sveditor.core/sve_compiler_wrappers/unix/wrapper
+++ b/sveditor/plugins/net.sf.sveditor.core/sve_compiler_wrappers/unix/wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #****************************************************************************
 #* wrapper
 #*
@@ -11,6 +11,12 @@ if test "x$SVE_COMPILER_ARGS_FILE" = "x"; then
 fi
 
 target=`basename $0`
+script=`which $target`
+script_dir=`dirname $script`
+
+export PATH=`echo $PATH | sed -e "s%${script_dir}:%%" -e "s%:${script_dir}%%"`
+
+declare -a exec_args=($target)
 
 echo "/**" >> $SVE_COMPILER_ARGS_FILE
 echo " * Invoking $target in $CWD" >> $SVE_COMPILER_ARGS_FILE
@@ -19,6 +25,8 @@ echo " */" >> $SVE_COMPILER_ARGS_FILE
 echo "-SVE_SET_CWD `pwd`" >> $SVE_COMPILER_ARGS_FILE
 
 while test -n "$1"; do
+	exec_args=( ${exec_args[@]} "$1" )
+	
 	case "$1" in
 		*[[:space:]]*)
 			echo "\"$1\"" >> $SVE_COMPILER_ARGS_FILE
@@ -33,3 +41,7 @@ done
 
 echo "" >> $SVE_COMPILER_ARGS_FILE
 echo "" >> $SVE_COMPILER_ARGS_FILE
+
+if test "x$SVE_COMPILER_ARGS_EXEC" = "x1"; then
+	exec ${exec_args[@]}
+fi

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/wizards/imp/compilation/args/CompilationArgImportSrcInfoPage.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/wizards/imp/compilation/args/CompilationArgImportSrcInfoPage.java
@@ -56,6 +56,9 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 	private Text						fImportCmdText;
 	private String						fImportCmd;
 	
+	private Button						fExecCmdButton;
+	private boolean						fExecCmd;
+	
 	private Button						fImportButton;
 	private boolean						fImportRun;
 	
@@ -148,7 +151,7 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 		fAddToProjectButton.setSelection(true);
 		fAddToProject = true;
 
-		g = new Group(top, SWT.BORDER);
+		g = new Group(top, SWT.BORDER_SOLID);
 		g.setText("Compilation Command");
 		gd = new GridData(SWT.FILL, SWT.FILL, true, false);
 		gd.horizontalSpan = 3;
@@ -164,6 +167,15 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 		fImportCmdText = new Text(g, SWT.SINGLE+SWT.BORDER);
 		fImportCmdText.setLayoutData(gd);
 		fImportCmdText.addModifyListener(textModifyListener);
+		
+		fExecCmdButton = new Button(g, SWT.CHECK);
+		fExecCmdButton.setText("Execute Compiler Commands");
+		gd = new GridData(SWT.FILL, SWT.FILL, true, false);
+		gd.horizontalSpan = 3;
+		fExecCmdButton.setLayoutData(gd);
+		fExecCmdButton.addSelectionListener(selectionListener);
+		fExecCmd = true;
+		fExecCmdButton.setSelection(true);
 		
 		// Source directory
 		l = new Label(g, SWT.NONE);
@@ -212,6 +224,8 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 		fDestDirText.setText(fDestDir);
 		fSrcDir.setText(fSrcDirStr);
 		
+		sash.setWeights(new int[] {60, 40});
+		
 		validate();
 		
 		setControl(sash);
@@ -252,7 +266,7 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 				Exception exception = null;
 
 				try {
-					collector.process(srcdir_f, args);
+					collector.process(srcdir_f, args, fExecCmd);
 				} catch (IOException e) {
 					exception = e;
 				}
@@ -451,6 +465,8 @@ public class CompilationArgImportSrcInfoPage extends WizardPage {
 				runCompilation();
 			} else if (src == fAddToProjectButton) {
 				fAddToProject = fAddToProjectButton.getSelection();
+			} else if (src == fExecCmdButton) {
+				fExecCmd = fExecCmdButton.getSelection();
 			}
 		}
 		


### PR DESCRIPTION
- #(enh) - During compilation-argument import, add support for executing
  the commands being intercepted by the compiler wrappers. Sometimes a
  compilation failure causes the entire process to terminate early.
