### PR TITLE
#426 Task markers (TODO/FIXME) not detected in multi-line comments

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,10 @@
 
 - #(425) - Correct an issue with the plugin-library indexer. Resolved a NPE
   issue during indexing
+------------------------------------------------------------------------------
+-- 1.8.6 Release --
+
+- #(426) Task markers (TODO/FIXME) not detected in multi-line comment
 
 ------------------------------------------------------------------------------
 -- 1.8.5 Release --

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestTaskTags.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestTaskTags.java
@@ -59,5 +59,83 @@ public class TestTaskTags extends SVCoreTestCaseBase {
 	
 		assertEquals(0, markers.size());
 	}
+
+	public void testTaskInMLCOne() {
+		String doc =
+				"module top;\n" +
+						"	/* TODO: must fix this implementation*/\n" +
+						"	always @(posedge clk) begin\n" +
+						"	end\n" +
+						"endmodule\n"
+						;
+		List<SVDBMarker> markers = new ArrayList<SVDBMarker>();
+		SVDBTestUtils.parse(fLog, doc, getName(), markers);
+		
+		assertEquals(1, markers.size());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(0).getMarkerType());
+		assertEquals("TODO: must fix this implementation",
+				markers.get(0).getMessage());
+	}
 	
+	public void testTaskInMLC() {
+		String doc =
+				"module top;\n" +
+						"	/*\n" +
+						"	 * FIXME must fix this implementation\n" +
+						"	 */\n" +
+						"	always @(posedge clk) begin\n" +
+						"	end\n" +
+						"endmodule\n"
+						;
+		
+		List<SVDBMarker> markers = new ArrayList<SVDBMarker>();
+		SVDBTestUtils.parse(fLog, doc, getName(), markers);
+		
+		assertEquals(1, markers.size());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(0).getMarkerType());
+		assertEquals("FIXME must fix this implementation",
+				markers.get(0).getMessage());
+	}
+	
+	public void testTaskNoReason() {
+		String doc =
+				"module top;\n" +
+						"	/**\n" +
+						"	 * FIXME\n" +
+						"	 */\n" +
+						"	always @(posedge clk) begin end\n" +
+						"	/**\n" +
+						"	 * FIXME:\n" +
+						"	 */\n" +
+						"	always @(posedge clk) begin end\n" +
+						"	/**\n" +
+						"	 * FIXME: \n" +
+						"	 */\n" +
+						"	always @(posedge clk) begin end\n" +
+						"	/**\n" +
+						"	 * FIXME: thing\n" +
+						"	 */\n" +
+						"	always @(posedge clk) begin\n" +
+						"	end\n" +
+						"endmodule\n"
+						;
+		
+		List<SVDBMarker> markers = new ArrayList<SVDBMarker>();
+		SVDBTestUtils.parse(fLog, doc, getName(), markers);
+		String S;
+		for (int i=0; i<markers.size(); i++)  {
+			S = markers.get(i).getMessage();
+		}
+		assertEquals(4, markers.size());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(0).getMarkerType());
+		assertEquals("FIXME ", markers.get(0).getMessage());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(1).getMarkerType());
+		assertEquals("FIXME :", markers.get(1).getMessage());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(2).getMarkerType());
+		assertEquals("FIXME: ", markers.get(2).getMessage());
+		assertEquals(SVDBMarker.MarkerType.Task, markers.get(3).getMarkerType());
+		assertEquals("FIXME: thing", markers.get(3).getMessage());
+	}
+	
+
 }

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/SVPreProcessor2.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/preproc/SVPreProcessor2.java
@@ -213,8 +213,12 @@ public class SVPreProcessor2 extends AbstractTextScanner
 						while ((ch = get_ch()) != -1) {
 							end_comment1 = end_comment2;
 							end_comment2 = ch;
+							
+							String S = fCommentBuffer.toString(); 
 
 							if (end_comment1 == '*' && end_comment2 == '/') {
+								// Remove trailing *
+								fCommentBuffer.deleteCharAt(fCommentBuffer.length()-1);
 								endComment();
 								break;
 							} else {


### PR DESCRIPTION
Updated pattern compilers to use \s instead of spaces to help sort out some matching issues seen
