### PR TITLE
#502 Format /beautifier of new feature matching begin/end code

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,7 +1,9 @@
 
 ------------------------------------------------------------------------------
 -- 2.0.2 Release --
-?- #(enh) - Add scrollbar to New Class "Add to Package" wizard
+- #(enh) - Add scrollbar to New Class "Add to Package" wizard
+
+- #(502) - Format /beautifier of new feature matching begin/end code is not working with some cases, besides it is broken in 2.0.1
 
 ------------------------------------------------------------------------------
 -- 2.0.1 Release --

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVCharacterPairMatcher.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/editor/SVCharacterPairMatcher.java
@@ -34,7 +34,6 @@ public class SVCharacterPairMatcher implements ICharacterPairMatcher {
 			SVDocumentPartitions.SV_MULTILINE_COMMENT,
 			SVDocumentPartitions.SV_SINGLELINE_COMMENT
 	};
-	private final int [] 				fDelims = {-1, ' ', '\t', '\n', '\r', ':'};
 	
 	/**
 	 * Defaults to verilog pairs
@@ -469,20 +468,21 @@ public class SVCharacterPairMatcher implements ICharacterPairMatcher {
 		
 	}
 	/**
-	 * Returns true if character is a delimiter
+	 * Returns true if character is a non-word character
 	 * 
-	 * Delimters are: ' ', '\t', '\n', '\r', ':' (the : because you could have begin:a_label)
+	 * Words continue in the space a-z A-Z _ 0-9
 	 * 
 	 * @param ch
 	 * @return
 	 */
 	private boolean IsCharDelimiter (int ch)  {
-		for (int i=0; i<fDelims.length; i++)  {
-			if (ch == fDelims[i])  {
-				return(true);
-			}
+		if (((ch >= 'a') && (ch <= 'z')) ||  
+		    ((ch >= 'A') && (ch <= 'Z')) ||  
+		    ((ch >= '0') && (ch <= '9')) ||  
+		    (ch == '_')
+		    )  {
+			return (false);
 		}
-		return (false);
-		
+		return (true);
 	}
 }

--- a/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/scanutils/SVDocumentTextScannerBase.java
+++ b/sveditor/plugins/net.sf.sveditor.ui/src/net/sf/sveditor/ui/scanutils/SVDocumentTextScannerBase.java
@@ -136,11 +136,24 @@ public class SVDocumentTextScannerBase
 							fIdx++;
 							break;
 						} else {
+							// Start of comment ... return immediately
 							if (fIdx == r.getOffset()) {
-								// Interpret a comment as a single whitespace char to
-								// prevent cross-comment content assist
+								ch = ' ';
+								fIdx ++;
+								break;
+							}
+							// End of comment ... return
+							else if (fIdx == (r.getOffset() + r.getLength()-1)) {
 								ch = ' ';
 								fIdx++;
+								break;
+							}
+							// Enter in the middle of a comment ... jump to end and return
+							else if ((fIdx > r.getOffset()) && (fIdx < (r.getOffset()+r.getLength()-1))) {
+								// Interpret a comment as a single whitespace char to
+								// prevent cross-comment content assist
+								fIdx = r.getOffset()+r.getLength();
+								ch = ' ';
 								break;
 							} else {
 								fIdx++;
@@ -167,9 +180,22 @@ public class SVDocumentTextScannerBase
 							fIdx--;
 							break;
 						} else {
-							if (fIdx == (r.getOffset() + r.getLength()-1)) {
+							// Start of comment ... return immediately
+							if (fIdx == r.getOffset()) {
 								ch = ' ';
 								fIdx--;
+								break;
+							}
+							// End of comment ... return immediately
+							else if (fIdx == (r.getOffset() + r.getLength()-1)) {
+								ch = ' ';
+								fIdx --;
+								break;
+							}
+							// Enter in the middle of a comment ... jump to start and return
+							else if ((fIdx > r.getOffset()) && (fIdx < (r.getOffset()+r.getLength()-1))) {
+								fIdx = r.getOffset();
+								ch = ' ';
 								break;
 							} else {
 								fIdx--;


### PR DESCRIPTION
is not working with some cases, besides it is broken in 2.0.1

The TextScannerBase has been modified to be more consistent when
skipping commented regions.
- Should be a bit more light weight (will skip to the end of the region)
rather than going through every line item
- Will always return 2 ' ', regardless of whether you can into a
comment, or if your entry point is in the middle of a comment