### PR TITLE
Fix for #529 - Specify blocks don't parse correctly for min:typ:max

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,8 @@
 
 - #(enh) - Add scrollbar to New Class "Add to Package" wizard
 
+- #(529) Specify blocks don't parse correctly for min:typ:max timing data
+
 ------------------------------------------------------------------------------
 -- 2.1.4 Release --
 

--- a/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseSpecify.java
+++ b/sveditor/plugins/net.sf.sveditor.core.tests/src/net/sf/sveditor/core/tests/parser/TestParseSpecify.java
@@ -43,7 +43,16 @@ public class TestParseSpecify extends TestCase {
 				"		(in1,in2  *> (out-:out2)) = (600,600); // multi-to-range\n" +
 				"		(in1,in2  *> (out+:out2)) = (600,600); // multi-to-range\n" +
 				"		(in1,in2  *> (out :out2)) = (600,600); // multi-to-range\n" +
-				"		(in      -*> out1,out2) = (600,600); // single-to-multi\n" +
+				"		// Min-typ-max equivalents - Bug 520\n" +
+				"		(in => out) = (400:500:600,400:500:600);\n" +
+				"		(in +=> out) = (400:500:600,400:500:600);\n" +
+				"		(in -=> out) = (400:500:600,400:500:600);\n" +
+				"		(in1,in2[1]  *> out      ) = (400:500:600,400:500:600,400:500:600); // multi-to-single\n" +
+				"		(in1,in2  *> (out-:out2)) = (400:500:600,400:500:600); // multi-to-range\n" +
+				"		(in1,in2  *> (out+:out2)) = (400:500:600,400:500:600); // multi-to-range\n" +
+				"		(in1,in2  *> (out :out2)) = (400:500:600,400:500:600); // multi-to-range\n" +
+				"		(posedge clk => (q[0]:data)) = (15,8);\n" +
+				"		(posedge clk => (q[0]:data)) = (1:2:3,4:5:6);\n" +
 				"		(in1,in2 +*> out1,out2) = (600,600); //multi-to-multi\n" +
 				"		if (RD==1) (posedge CLK *> (out3[1]:out3[0])) = (600,600); //multi-to-multi\n" +
 				"	endspecify\n" +

--- a/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
+++ b/sveditor/plugins/net.sf.sveditor.core/src/net/sf/sveditor/core/parser/SVExprParser.java
@@ -319,7 +319,7 @@ public class SVExprParser extends SVParserBase {
 		}
 
 		while (fLexer.peek() != null) {
-			expression();
+			constant_mintypmax_expression();
 			
 			if (fLexer.peekOperator(OP.COMMA)) {
 				fLexer.eatToken();


### PR DESCRIPTION
timing data